### PR TITLE
Change api key header as it is not valid by default in nginx with und…

### DIFF
--- a/lighthouse/authorization.py
+++ b/lighthouse/authorization.py
@@ -4,7 +4,7 @@ from eve.auth import BasicAuth  # type: ignore
 
 class APIKeyAuth(BasicAuth):
     def check_auth(self, headers):
-        api_key = headers.get("LIGHTHOUSE_API_KEY")
+        api_key = headers.get("x-lighthouse-client")
 
         if api_key:
             return api_key == current_app.config["LIGHTHOUSE_API_KEY"]

--- a/tests/requests/test_samples_declarations.py
+++ b/tests/requests/test_samples_declarations.py
@@ -51,7 +51,7 @@ def post_authorized_create_samples_declaration(client, payload):
         "/samples_declarations",
         data=json.dumps(payload),
         content_type="application/json",
-        headers={"LIGHTHOUSE_API_KEY": "develop"},
+        headers={"x-lighthouse-client": "develop"},
     )
 
 


### PR DESCRIPTION
…erscores.

New header:
        x-lighthouse-client

Closes #

Changes proposed in this pull request:

*
*
* ...
