### PR TITLE
Setting timeout to 2 minutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN pipenv install --dev --ignore-pipfile --system --deploy
 
 ADD . /code/
 
-CMD ["gunicorn", "-b", "0.0.0.0:8000", "lighthouse:create_app()"]
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "-t", "120","lighthouse:create_app()"]


### PR DESCRIPTION
Increased timeout in Dockerfile to 2 minutes. 
Test locally `gunicorn -b 0.0.0.0:8000 -t 120 "lighthouse:create_app()"`
