### PR TITLE
GPL-568 increase max results limit for endpoint

### DIFF
--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -48,6 +48,8 @@ DATE_FORMAT = r"%Y-%m-%dT%H:%M:%S"
 # eg "2013-04-04T10:29:13"
 
 PAGINATION_LIMIT = 10000
+# allow requests to set ?max_results= to more than the default
+# added for lighthouse-ui Imports page, to display all Imports in a table
 
 DOMAIN: Dict = {
     "samples": {},

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -47,6 +47,8 @@ SAMPLES_DECLARATIONS_SCHEMA: Dict = {
 DATE_FORMAT = r"%Y-%m-%dT%H:%M:%S"
 # eg "2013-04-04T10:29:13"
 
+PAGINATION_LIMIT = 10000
+
 DOMAIN: Dict = {
     "samples": {},
     "imports": {},


### PR DESCRIPTION
Set pagination limit so that requests to this endpoint can put ?max_results=10000 and it will work

- real reason is because for GPL-568, in lighthouse-ui Imports page we want to return all imports at once (~350 records at the moment)
- previous limit was 50, as that is the default
- see Eve documentation