### PR TITLE
GPL-609 fix

### DIFF
--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -305,14 +305,16 @@ def join_samples_declarations(positive_samples):
     )
 
     declarations_records = [record for record in declarations]
+
     if len(declarations_records) > 0:
         logger.debug("Joining declarations")
         declarations_frame = pd.DataFrame.from_records(declarations_records)
-        merged = positive_samples.merge(declarations_frame, how="left", on="Root Sample ID")
+        result = positive_samples.merge(declarations_frame, how="left", on="Root Sample ID")
 
         # Give a default value of Unknown to any entry that does not have a
         # sample declaration
-        merged = merged.fillna({"Value In Sequencing": "Unknown"})
-    
-    return merged
+        result = result.fillna({"Value In Sequencing": "Unknown"})
+        return result
+
+    return positive_samples
 

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -205,5 +205,15 @@ def test_join_samples_declarations(app, freezer, samples_declarations, samples_n
 
         assert joined.at[1, 'Root Sample ID'] == 'MCM010'
         assert joined.at[1, 'Value In Sequencing'] == 'Unknown'
-  
-    
+
+def test_join_samples_declarations_empty_collection(app, freezer, samples_no_declaration):
+    # samples_declaration collection is empty because we are not passing in the fixture
+
+    with app.app_context():
+        samples = app.data.driver.db.samples
+        positive_samples = get_all_positive_samples(samples)
+        joined = join_samples_declarations(positive_samples)
+
+        assert np.array_equal(positive_samples.to_numpy(), joined.to_numpy())
+
+


### PR DESCRIPTION
Fix for 'ERROR local variable 'merged' referenced before assignment', from `return merged` line where samples_declaration collection is empty
