### PR TITLE
Gpl 618 bug cherrypicked column doesnt cope with repeat samples

### DIFF
--- a/lighthouse/config/development.py
+++ b/lighthouse/config/development.py
@@ -6,18 +6,8 @@ from lighthouse.config.defaults import *  # noqa: F403, F401
 SCHEDULER_RUN = False
 
 # Eve config
-# MONGO_HOST = "127.0.0.1"
-# MONGO_DBNAME = "lighthouseDevelopmentDB"
-
-MONGO_HOST = "vm-mg-psd-uat1.internal.sanger.ac.uk"
-MONGO_DBNAME = "lighthouseUATDB"
-MONGO_URI = (
-    "mongodb://lighthouse_owner:ora7gepe7@vm-mg-psd-uat1.internal.sanger.ac.uk/lighthouseUATDB"
-)
-# MLWH_CONN_STRING: "mlwhd_admin:jEbRepuJe7@mlwh-db:3436"
-MLWH_CONN_STRING: "mlwh_admin:pESatUpr8S@mlwh-db:3435"
-ML_WH_DB = "mlwhd_mlwarehouse_devdata"
-EVENTS_WH_DB = "mlwhd_mlwh_events_proddata"
+MONGO_HOST = "127.0.0.1"
+MONGO_DBNAME = "lighthouseDevelopmentDB"
 
 # logging config
 LOGGING["loggers"]["lighthouse"]["level"] = "DEBUG"  # noqa: F405

--- a/lighthouse/config/development.py
+++ b/lighthouse/config/development.py
@@ -6,8 +6,16 @@ from lighthouse.config.defaults import *  # noqa: F403, F401
 SCHEDULER_RUN = False
 
 # Eve config
-MONGO_HOST = "127.0.0.1"
-MONGO_DBNAME = "lighthouseDevelopmentDB"
+# MONGO_HOST = "127.0.0.1"
+# MONGO_DBNAME = "lighthouseDevelopmentDB"
+
+MONGO_HOST = "vm-mg-psd-uat1.internal.sanger.ac.uk"
+MONGO_DBNAME = "lighthouseUATDB"
+MONGO_URI = "mongodb://lighthouse_owner:ora7gepe7@vm-mg-psd-uat1.internal.sanger.ac.uk/lighthouseUATDB"
+# MLWH_CONN_STRING: "mlwhd_admin:jEbRepuJe7@mlwh-db:3436"
+MLWH_CONN_STRING: "mlwh_admin:pESatUpr8S@mlwh-db:3435"
+ML_WH_DB = "mlwhd_mlwarehouse_devdata"
+EVENTS_WH_DB = "mlwhd_mlwh_events_proddata"
 
 # logging config
 LOGGING["loggers"]["lighthouse"]["level"] = "DEBUG"  # noqa: F405

--- a/lighthouse/config/development.py
+++ b/lighthouse/config/development.py
@@ -11,7 +11,9 @@ SCHEDULER_RUN = False
 
 MONGO_HOST = "vm-mg-psd-uat1.internal.sanger.ac.uk"
 MONGO_DBNAME = "lighthouseUATDB"
-MONGO_URI = "mongodb://lighthouse_owner:ora7gepe7@vm-mg-psd-uat1.internal.sanger.ac.uk/lighthouseUATDB"
+MONGO_URI = (
+    "mongodb://lighthouse_owner:ora7gepe7@vm-mg-psd-uat1.internal.sanger.ac.uk/lighthouseUATDB"
+)
 # MLWH_CONN_STRING: "mlwhd_admin:jEbRepuJe7@mlwh-db:3436"
 MLWH_CONN_STRING: "mlwh_admin:pESatUpr8S@mlwh-db:3435"
 ML_WH_DB = "mlwhd_mlwarehouse_devdata"

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -7,11 +7,12 @@ import requests
 import pandas as pd  # type: ignore
 
 import pymysql
+
 # we only need the create_engine method
 # but that can't be mocked
 # can't seem to mock it at the top because
 # it is outside the app context
-import sqlalchemy # type: ignore
+import sqlalchemy  # type: ignore
 
 from datetime import datetime
 from typing import Dict, List, Tuple
@@ -154,9 +155,7 @@ def map_labware_to_location(labware_barcodes):
     ]
 
     labware_to_location_barcode_df = pd.DataFrame.from_records(labware_to_location_barcode)
-    logger.info(
-        f"{len(labware_to_location_barcode_df.index)} locations for plate barcodes found"
-    )
+    logger.info(f"{len(labware_to_location_barcode_df.index)} locations for plate barcodes found")
     pretty(logger, labware_to_location_barcode_df)
 
     return labware_to_location_barcode_df
@@ -198,23 +197,27 @@ def get_cherrypicked_samples(root_sample_ids, plate_barcodes):
     root_sample_id_string = "'" + "','".join(root_sample_ids) + "'"
     plate_barcodes_string = "'" + "','".join(plate_barcodes) + "'"
 
-    ml_wh_db = app.config['ML_WH_DB']
-    events_wh_db = app.config['EVENTS_WH_DB']
+    ml_wh_db = app.config["ML_WH_DB"]
+    events_wh_db = app.config["EVENTS_WH_DB"]
 
-    sql = ("select mlwh_sample.description as `Root Sample ID`"
-                f" FROM {app.config['ML_WH_DB']}.sample as mlwh_sample"
-                f" JOIN {app.config['ML_WH_DB']}.stock_resource mlwh_stock_resource ON (mlwh_sample.id_sample_tmp = mlwh_stock_resource.id_sample_tmp)"
-                f" JOIN {app.config['EVENTS_WH_DB']}.subjects mlwh_events_subjects ON (mlwh_events_subjects.friendly_name = sanger_sample_id)"
-                f" JOIN {app.config['EVENTS_WH_DB']}.roles mlwh_events_roles ON (mlwh_events_roles.subject_id = mlwh_events_subjects.id)"
-                f" JOIN {app.config['EVENTS_WH_DB']}.events mlwh_events_events ON (mlwh_events_roles.event_id = mlwh_events_events.id)"
-                f" JOIN {app.config['EVENTS_WH_DB']}.event_types mlwh_events_event_types ON (mlwh_events_events.event_type_id = mlwh_events_event_types.id)"
-                f" WHERE mlwh_sample.description IN ({root_sample_id_string})"
-                f" AND mlwh_stock_resource.labware_human_barcode IN ({plate_barcodes_string})"
-                " AND mlwh_events_event_types.key = 'cherrypick_layout_set'"
-                " GROUP BY mlwh_sample.description")
+    sql = (
+        "select mlwh_sample.description as `Root Sample ID`"
+        f" FROM {app.config['ML_WH_DB']}.sample as mlwh_sample"
+        f" JOIN {app.config['ML_WH_DB']}.stock_resource mlwh_stock_resource ON (mlwh_sample.id_sample_tmp = mlwh_stock_resource.id_sample_tmp)"
+        f" JOIN {app.config['EVENTS_WH_DB']}.subjects mlwh_events_subjects ON (mlwh_events_subjects.friendly_name = sanger_sample_id)"
+        f" JOIN {app.config['EVENTS_WH_DB']}.roles mlwh_events_roles ON (mlwh_events_roles.subject_id = mlwh_events_subjects.id)"
+        f" JOIN {app.config['EVENTS_WH_DB']}.events mlwh_events_events ON (mlwh_events_roles.event_id = mlwh_events_events.id)"
+        f" JOIN {app.config['EVENTS_WH_DB']}.event_types mlwh_events_event_types ON (mlwh_events_events.event_type_id = mlwh_events_event_types.id)"
+        f" WHERE mlwh_sample.description IN ({root_sample_id_string})"
+        f" AND mlwh_stock_resource.labware_human_barcode IN ({plate_barcodes_string})"
+        " AND mlwh_events_event_types.key = 'cherrypick_layout_set'"
+        " GROUP BY mlwh_sample.description"
+    )
 
     try:
-        sql_engine = sqlalchemy.create_engine(f"mysql+pymysql://{app.config['MLWH_CONN_STRING']}", pool_recycle=3600)
+        sql_engine = sqlalchemy.create_engine(
+            f"mysql+pymysql://{app.config['MLWH_CONN_STRING']}", pool_recycle=3600
+        )
         db_connection = sql_engine.connect()
         frame = pd.read_sql(sql, db_connection)
         return frame
@@ -223,6 +226,7 @@ def get_cherrypicked_samples(root_sample_ids, plate_barcodes):
         return None
     finally:
         db_connection.close()
+
 
 def get_all_positive_samples(samples):
 
@@ -258,18 +262,22 @@ def get_all_positive_samples(samples):
 
     return positive_samples_df
 
+
 def add_cherrypicked_column(existing_dataframe):
 
-    root_sample_ids = existing_dataframe['Root Sample ID'].to_list()
-    plate_barcodes = existing_dataframe['plate_barcode'].unique()
+    root_sample_ids = existing_dataframe["Root Sample ID"].to_list()
+    plate_barcodes = existing_dataframe["plate_barcode"].unique()
 
     cherrypicked_samples_df = get_cherrypicked_samples(root_sample_ids, plate_barcodes)
-    cherrypicked_samples_df['LIMS submission'] = 'Yes'
+    cherrypicked_samples_df["LIMS submission"] = "Yes"
 
-    existing_dataframe = existing_dataframe.merge(cherrypicked_samples_df, how="left", on="Root Sample ID")
-    existing_dataframe = existing_dataframe.fillna({'LIMS submission': 'No'})
+    existing_dataframe = existing_dataframe.merge(
+        cherrypicked_samples_df, how="left", on="Root Sample ID"
+    )
+    existing_dataframe = existing_dataframe.fillna({"LIMS submission": "No"})
 
     return existing_dataframe
+
 
 def get_distinct_plate_barcodes(samples):
 
@@ -284,11 +292,12 @@ def get_distinct_plate_barcodes(samples):
 
     return distinct_plate_barcodes
 
+
 def join_samples_declarations(positive_samples):
 
     samples_declarations = app.data.driver.db.samples_declarations
 
-     # Latest declarations group by root_sample_id
+    # Latest declarations group by root_sample_id
     # Id is needed to control the group aggregation
     # Excel formatter required date without timezone
     declarations = samples_declarations.aggregate(
@@ -323,4 +332,3 @@ def join_samples_declarations(positive_samples):
         return result
 
     return positive_samples
-

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -194,6 +194,7 @@ def get_locations_from_labwhere(labware_barcodes):
 def get_cherrypicked_samples(root_sample_ids, plate_barcodes):
     # Find which samples have been cherrypicked using MLWH & Events warehouse
     # Returns dataframe with 1 column, 'Root Sample ID', containing Root Sample ID of those that have been cherrypicked
+    # TODO: move into external method.
     root_sample_id_string = "'" + "','".join(root_sample_ids) + "'"
     plate_barcodes_string = "'" + "','".join(plate_barcodes) + "'"
 

--- a/lighthouse/jobs/reports.py
+++ b/lighthouse/jobs/reports.py
@@ -33,6 +33,8 @@ def create_report() -> str:
     samples = app.data.driver.db.samples
     positive_samples_df = get_all_positive_samples(samples)
 
+    
+
     logger.debug("Getting location barcodes from labwhere")
     labware_to_location_barcode_df = map_labware_to_location(get_distinct_plate_barcodes(samples))
 

--- a/lighthouse/jobs/reports.py
+++ b/lighthouse/jobs/reports.py
@@ -12,11 +12,12 @@ from lighthouse.helpers.reports import (
     get_all_positive_samples,
     add_cherrypicked_column,
     get_distinct_plate_barcodes,
-    join_samples_declarations
+    join_samples_declarations,
 )
 from lighthouse.utils import pretty
 
 logger = logging.getLogger(__name__)
+
 
 def create_report() -> str:
     """Creates a positve samples on site record using the samples collection and location
@@ -32,8 +33,6 @@ def create_report() -> str:
     logger.debug("Getting all positive samples")
     samples = app.data.driver.db.samples
     positive_samples_df = get_all_positive_samples(samples)
-
-    
 
     logger.debug("Getting location barcodes from labwhere")
     labware_to_location_barcode_df = map_labware_to_location(get_distinct_plate_barcodes(samples))
@@ -80,7 +79,3 @@ def create_report_job():
     logger.info("Starting create_report job")
     with scheduler.app.app_context():
         create_report()
-
-
-
-

--- a/tests/blueprints/test_reports.py
+++ b/tests/blueprints/test_reports.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 import pandas as pd
 
+
 def test_get_reports_endpoint(client):
     with patch(
         "lighthouse.blueprints.reports.get_reports_details", return_value=[],
@@ -18,7 +19,9 @@ def test_get_reports_list(client):
         assert response.json == {"reports": []}
 
 
-def test_create_report(client, app, tmp_path, samples, labwhere_samples_simple, samples_declarations):
+def test_create_report(
+    client, app, tmp_path, samples, labwhere_samples_simple, samples_declarations
+):
     with app.app_context():
         with patch(
             "lighthouse.jobs.reports.get_new_report_name_and_path",
@@ -30,7 +33,7 @@ def test_create_report(client, app, tmp_path, samples, labwhere_samples_simple, 
             ):
                 with patch(
                     "lighthouse.helpers.reports.get_cherrypicked_samples",
-                    return_value=pd.DataFrame(['MCM001'], columns=['Root Sample ID'])
+                    return_value=pd.DataFrame(["MCM001"], columns=["Root Sample ID"]),
                 ):
                     response = client.post("/reports/new")
                     assert response.json == {"reports": "Some details of a report"}
@@ -55,6 +58,7 @@ def test_delete_reports_endpoint(client):
         response = client.post("delete_reports", json=json_body)
 
         assert response.status_code == HTTPStatus.OK
+
 
 def test_delete_reports_endpoint_fails(client):
     with patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from .data.fixture_data import (
     LOTS_OF_SAMPLES,
     LOTS_OF_SAMPLES_DECLARATIONS_PAYLOAD,
     MULTIPLE_ERRORS_SAMPLES_DECLARATIONS,
-    SAMPLES_NO_DECLARATION
+    SAMPLES_NO_DECLARATION,
 )
 
 
@@ -110,6 +110,7 @@ def samples(app):
     with app.app_context():
         samples_collection.delete_many({})
 
+
 @pytest.fixture
 def samples_no_declaration(app):
     with app.app_context():
@@ -122,6 +123,7 @@ def samples_no_declaration(app):
     # clear up after the fixture is used
     with app.app_context():
         samples_collection.delete_many({})
+
 
 @pytest.fixture
 def mocked_responses():
@@ -138,18 +140,22 @@ def labwhere_samples_simple(app, mocked_responses):
         responses.POST, labwhere_url, body=body, status=HTTPStatus.OK,
     )
 
+
 @pytest.fixture
 def labwhere_samples_multiple(app, mocked_responses):
     labwhere_url = f"http://{app.config['LABWHERE_URL']}/api/labwares/searches"
 
-    body = json.dumps([
-        {"barcode": "123", "location": {"barcode": "4567"}},
-        {"barcode": "456", "location": {"barcode": "1234"}},
-        {"barcode": "789", "location": {}}
-    ])
+    body = json.dumps(
+        [
+            {"barcode": "123", "location": {"barcode": "4567"}},
+            {"barcode": "456", "location": {"barcode": "1234"}},
+            {"barcode": "789", "location": {}},
+        ]
+    )
     mocked_responses.add(
         responses.POST, labwhere_url, body=body, status=HTTPStatus.OK,
     )
+
 
 @pytest.fixture
 def labwhere_samples_error(app, mocked_responses):

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -15,7 +15,7 @@ from lighthouse.helpers.reports import (
     map_labware_to_location,
     add_cherrypicked_column,
     get_distinct_plate_barcodes,
-    join_samples_declarations
+    join_samples_declarations,
 )
 from lighthouse.exceptions import ReportCreationError
 
@@ -66,23 +66,25 @@ def test_delete_reports(app, freezer):
     for filename in filenames:
         assert os.path.isfile(f"{app.config['REPORTS_DIR']}/{filename}") == False
 
+
 def test_get_cherrypicked_samples(app, freezer):
 
-  expected = pd.DataFrame(['MCM001', 'MCM003', 'MCM005'], columns=['Root Sample ID'], index=[0, 1, 2])
-  samples = ['MCM001','MCM002','MCM003','MCM004','MCM005']
-  plate_barcodes = ['123', '456']
+    expected = pd.DataFrame(
+        ["MCM001", "MCM003", "MCM005"], columns=["Root Sample ID"], index=[0, 1, 2]
+    )
+    samples = ["MCM001", "MCM002", "MCM003", "MCM004", "MCM005"]
+    plate_barcodes = ["123", "456"]
 
-  with app.app_context():
-    with patch(
-      "sqlalchemy.create_engine", return_value=Mock()
-    ):
-      with patch(
-          "pandas.read_sql", return_value=expected,
-        ):
-        returned_samples = get_cherrypicked_samples(samples, plate_barcodes)
-        assert returned_samples.at[0, 'Root Sample ID'] == "MCM001"
-        assert returned_samples.at[1, 'Root Sample ID'] == "MCM003"
-        assert returned_samples.at[2, 'Root Sample ID'] == "MCM005"
+    with app.app_context():
+        with patch("sqlalchemy.create_engine", return_value=Mock()):
+            with patch(
+                "pandas.read_sql", return_value=expected,
+            ):
+                returned_samples = get_cherrypicked_samples(samples, plate_barcodes)
+                assert returned_samples.at[0, "Root Sample ID"] == "MCM001"
+                assert returned_samples.at[1, "Root Sample ID"] == "MCM003"
+                assert returned_samples.at[2, "Root Sample ID"] == "MCM005"
+
 
 def test_get_all_positive_samples(app, freezer, samples):
 
@@ -91,12 +93,13 @@ def test_get_all_positive_samples(app, freezer, samples):
         positive_samples = get_all_positive_samples(samples)
 
         assert len(positive_samples) == 1
-        assert positive_samples.at[0,'Root Sample ID'] == 'MCM001'
-        assert positive_samples.at[0,'Result'] == 'Positive'
-        assert positive_samples.at[0,'source'] == 'test1'
-        assert positive_samples.at[0,'plate_barcode'] == '123'
-        assert positive_samples.at[0,'coordinate'] == 'A1'
-        assert positive_samples.at[0,'plate and well'] == '123:A1'
+        assert positive_samples.at[0, "Root Sample ID"] == "MCM001"
+        assert positive_samples.at[0, "Result"] == "Positive"
+        assert positive_samples.at[0, "source"] == "test1"
+        assert positive_samples.at[0, "plate_barcode"] == "123"
+        assert positive_samples.at[0, "coordinate"] == "A1"
+        assert positive_samples.at[0, "plate and well"] == "123:A1"
+
 
 def test_map_labware_to_location_labwhere_error(app, freezer, labwhere_samples_error):
     # mocks response from get_locations_from_labwhere() with labwhere_samples_error
@@ -105,97 +108,88 @@ def test_map_labware_to_location_labwhere_error(app, freezer, labwhere_samples_e
 
     try:
         with app.app_context():
-            map_labware_to_location(['test'])
+            map_labware_to_location(["test"])
     except ReportCreationError:
         raised_exception = True
 
     assert raised_exception
 
+
 def test_map_labware_to_location_dataframe_content(app, freezer, labwhere_samples_multiple):
     # mocks response from get_locations_from_labwhere() with labwhere_samples_multiple
     with app.app_context():
-        result = map_labware_to_location(['123', '456', '789']) # '789' returns no location, in the mock
+        result = map_labware_to_location(
+            ["123", "456", "789"]
+        )  # '789' returns no location, in the mock
 
-    expected_columns = ['plate_barcode', 'location_barcode']
-    expected_data = [
-        ['123', '4567'],
-        ['456', '1234'],
-        ['789', '']
-    ]
+    expected_columns = ["plate_barcode", "location_barcode"]
+    expected_data = [["123", "4567"], ["456", "1234"], ["789", ""]]
     assert result.columns.to_list() == expected_columns
     assert np.array_equal(result.to_numpy(), expected_data)
+
 
 def test_add_cherrypicked_column(app, freezer):
     # mocks response from get_cherrypicked_samples()
     existing_dataframe = pd.DataFrame(
-        [
-            ['MCM001', '123', 'TEST'],
-            ['MCM002', '123', 'TEST'],
-            ['MCM003', '123', 'TEST']
-        ],
-        columns=['Root Sample ID', 'plate_barcode', 'Lab ID']
+        [["MCM001", "123", "TEST"], ["MCM002", "123", "TEST"], ["MCM003", "123", "TEST"]],
+        columns=["Root Sample ID", "plate_barcode", "Lab ID"],
     )
 
-    mock_get_cherrypicked_samples = pd.DataFrame(['MCM001', 'MCM003'], columns=['Root Sample ID'])
+    mock_get_cherrypicked_samples = pd.DataFrame(["MCM001", "MCM003"], columns=["Root Sample ID"])
 
-    expected_columns = ['Root Sample ID', 'plate_barcode', 'Lab ID', 'LIMS submission']
+    expected_columns = ["Root Sample ID", "plate_barcode", "Lab ID", "LIMS submission"]
     expected_data = [
-        ['MCM001', '123', 'TEST', 'Yes'],
-        ['MCM002', '123', 'TEST', 'No'],
-        ['MCM003', '123', 'TEST', 'Yes']
+        ["MCM001", "123", "TEST", "Yes"],
+        ["MCM002", "123", "TEST", "No"],
+        ["MCM003", "123", "TEST", "Yes"],
     ]
 
     with app.app_context():
-        with patch(
-        "sqlalchemy.create_engine", return_value=Mock()
-        ):
+        with patch("sqlalchemy.create_engine", return_value=Mock()):
             with patch(
-                "lighthouse.helpers.reports.get_cherrypicked_samples", return_value=mock_get_cherrypicked_samples,
-                ):
+                "lighthouse.helpers.reports.get_cherrypicked_samples",
+                return_value=mock_get_cherrypicked_samples,
+            ):
 
                 new_dataframe = add_cherrypicked_column(existing_dataframe)
 
     assert new_dataframe.columns.to_list() == expected_columns
     assert np.array_equal(new_dataframe.to_numpy(), expected_data)
+
 
 def test_add_cherrypicked_column_no_rows(app, freezer):
     # mocks response from get_cherrypicked_samples()
     existing_dataframe = pd.DataFrame(
-        [
-            ['MCM001', '123', 'TEST'],
-            ['MCM002', '123', 'TEST'],
-        ],
-        columns=['Root Sample ID', 'plate_barcode', 'Lab ID']
+        [["MCM001", "123", "TEST"], ["MCM002", "123", "TEST"],],
+        columns=["Root Sample ID", "plate_barcode", "Lab ID"],
     )
 
     # Not sure if this is an accurate mock - haven't tried it with a real db connection
-    mock_get_cherrypicked_samples = pd.DataFrame([], columns=['Root Sample ID'])
+    mock_get_cherrypicked_samples = pd.DataFrame([], columns=["Root Sample ID"])
 
-    expected_columns = ['Root Sample ID', 'plate_barcode', 'Lab ID', 'LIMS submission']
-    expected_data = [
-        ['MCM001', '123', 'TEST', 'No'],
-        ['MCM002', '123', 'TEST', 'No']
-    ]
+    expected_columns = ["Root Sample ID", "plate_barcode", "Lab ID", "LIMS submission"]
+    expected_data = [["MCM001", "123", "TEST", "No"], ["MCM002", "123", "TEST", "No"]]
 
     with app.app_context():
-        with patch(
-        "sqlalchemy.create_engine", return_value=Mock()
-        ):
+        with patch("sqlalchemy.create_engine", return_value=Mock()):
             with patch(
-                "lighthouse.helpers.reports.get_cherrypicked_samples", return_value=mock_get_cherrypicked_samples,
-                ):
+                "lighthouse.helpers.reports.get_cherrypicked_samples",
+                return_value=mock_get_cherrypicked_samples,
+            ):
 
                 new_dataframe = add_cherrypicked_column(existing_dataframe)
 
     assert new_dataframe.columns.to_list() == expected_columns
     assert np.array_equal(new_dataframe.to_numpy(), expected_data)
+
 
 def test_get_distinct_plate_barcodes(app, freezer, samples):
 
     with app.app_context():
         samples = app.data.driver.db.samples
 
-        assert get_distinct_plate_barcodes(samples)[0] == '123'
+        assert get_distinct_plate_barcodes(samples)[0] == "123"
+
 
 def test_join_samples_declarations(app, freezer, samples_declarations, samples_no_declaration):
 
@@ -204,8 +198,9 @@ def test_join_samples_declarations(app, freezer, samples_declarations, samples_n
         positive_samples = get_all_positive_samples(samples)
         joined = join_samples_declarations(positive_samples)
 
-        assert joined.at[1, 'Root Sample ID'] == 'MCM010'
-        assert joined.at[1, 'Value In Sequencing'] == 'Unknown'
+        assert joined.at[1, "Root Sample ID"] == "MCM010"
+        assert joined.at[1, "Value In Sequencing"] == "Unknown"
+
 
 def test_join_samples_declarations_empty_collection(app, freezer, samples_no_declaration):
     # samples_declaration collection is empty because we are not passing in the fixture
@@ -216,5 +211,3 @@ def test_join_samples_declarations_empty_collection(app, freezer, samples_no_dec
         joined = join_samples_declarations(positive_samples)
 
         assert np.array_equal(positive_samples.to_numpy(), joined.to_numpy())
-
-

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -70,6 +70,7 @@ def test_get_cherrypicked_samples(app, freezer):
 
   expected = pd.DataFrame(['MCM001', 'MCM003', 'MCM005'], columns=['Root Sample ID'], index=[0, 1, 2])
   samples = ['MCM001','MCM002','MCM003','MCM004','MCM005']
+  plate_barcodes = ['123', '456']
 
   with app.app_context():
     with patch(
@@ -78,7 +79,7 @@ def test_get_cherrypicked_samples(app, freezer):
       with patch(
           "pandas.read_sql", return_value=expected,
         ):
-        returned_samples = get_cherrypicked_samples(samples)
+        returned_samples = get_cherrypicked_samples(samples, plate_barcodes)
         assert returned_samples.at[0, 'Root Sample ID'] == "MCM001"
         assert returned_samples.at[1, 'Root Sample ID'] == "MCM003"
         assert returned_samples.at[2, 'Root Sample ID'] == "MCM005"
@@ -128,20 +129,20 @@ def test_add_cherrypicked_column(app, freezer):
     # mocks response from get_cherrypicked_samples()
     existing_dataframe = pd.DataFrame(
         [
-            ['MCM001', 'TEST'],
-            ['MCM002', 'TEST'],
-            ['MCM003', 'TEST']
+            ['MCM001', '123', 'TEST'],
+            ['MCM002', '123', 'TEST'],
+            ['MCM003', '123', 'TEST']
         ],
-        columns=['Root Sample ID', 'Lab ID']
+        columns=['Root Sample ID', 'plate_barcode', 'Lab ID']
     )
 
     mock_get_cherrypicked_samples = pd.DataFrame(['MCM001', 'MCM003'], columns=['Root Sample ID'])
 
-    expected_columns = ['Root Sample ID', 'Lab ID', 'LIMS submission']
+    expected_columns = ['Root Sample ID', 'plate_barcode', 'Lab ID', 'LIMS submission']
     expected_data = [
-        ['MCM001', 'TEST', 'Yes'],
-        ['MCM002', 'TEST', 'No'],
-        ['MCM003', 'TEST', 'Yes']
+        ['MCM001', '123', 'TEST', 'Yes'],
+        ['MCM002', '123', 'TEST', 'No'],
+        ['MCM003', '123', 'TEST', 'Yes']
     ]
 
     with app.app_context():
@@ -161,19 +162,19 @@ def test_add_cherrypicked_column_no_rows(app, freezer):
     # mocks response from get_cherrypicked_samples()
     existing_dataframe = pd.DataFrame(
         [
-            ['MCM001', 'TEST'],
-            ['MCM002', 'TEST'],
+            ['MCM001', '123', 'TEST'],
+            ['MCM002', '123', 'TEST'],
         ],
-        columns=['Root Sample ID', 'Lab ID']
+        columns=['Root Sample ID', 'plate_barcode', 'Lab ID']
     )
 
     # Not sure if this is an accurate mock - haven't tried it with a real db connection
     mock_get_cherrypicked_samples = pd.DataFrame([], columns=['Root Sample ID'])
 
-    expected_columns = ['Root Sample ID', 'Lab ID', 'LIMS submission']
+    expected_columns = ['Root Sample ID', 'plate_barcode', 'Lab ID', 'LIMS submission']
     expected_data = [
-        ['MCM001', 'TEST', 'No'],
-        ['MCM002', 'TEST', 'No']
+        ['MCM001', '123', 'TEST', 'No'],
+        ['MCM002', '123', 'TEST', 'No']
     ]
 
     with app.app_context():

--- a/tests/requests/test_requests_reports.py
+++ b/tests/requests/test_requests_reports.py
@@ -2,10 +2,11 @@ from http import HTTPStatus
 from unittest.mock import patch
 import pandas as pd
 
+
 def test_create_report(client, samples, samples_declarations, labwhere_samples_simple):
     with patch(
         "lighthouse.helpers.reports.get_cherrypicked_samples",
-        return_value=pd.DataFrame(['MCM001'], columns=['Root Sample ID'])
+        return_value=pd.DataFrame(["MCM001"], columns=["Root Sample ID"]),
     ):
         response = client.post("/reports/new", content_type="application/json",)
         assert response.status_code == HTTPStatus.CREATED


### PR DESCRIPTION
Closes #91 

Changes proposed in this pull request:

* added extra stuff to the SQL to make sure that the plate barcodes are also included.

NOTE: I can't seem to get it running locally against UAT as it gives me an error database does not exist but if I paste the SQL and check it against the warehouse it works. We can try it in UAT to see if it works ...
