### PR TITLE
GPL-659 & GPL-nnn filter high ct out of reports and Lighthouse Sentinel

### DIFF
--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -21,3 +21,25 @@ MLWH_LH_SAMPLE_RNA_ID = "rna_id"
 MLWH_LH_SAMPLE_RESULT = "result"
 
 CT_VALUE_LIMIT = 30
+
+POSITIVE_SAMPLES_MONGODB_FILTER = {
+  FIELD_RESULT: {
+    "$regex": "^positive", "$options": "i"
+  },
+  "$or": [
+    {
+      "$and": [
+          { FIELD_CQ_1: None },
+          { FIELD_CQ_2: None },
+          { FIELD_CQ_3: None }
+      ]
+    },
+    {
+      "$or": [
+          { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} },
+          { FIELD_CQ_2: {"$lte": CT_VALUE_LIMIT} },
+          { FIELD_CQ_3: {"$lte": CT_VALUE_LIMIT} }
+      ]
+    }
+  ]
+}

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -12,9 +12,9 @@ FIELD_SOURCE = "source"
 FIELD_PLATE_BARCODE = "plate_barcode"
 FIELD_COG_BARCODE = "cog_barcode"
 FIELD_DATE_TESTED = "Date Tested"
-FIELD_CH1_CQ = "ch1_cq"
-FIELD_CH2_CQ = "ch2_cq"
-FIELD_CH3_CQ = "ch3_cq"
+FIELD_CH1_CQ = "CH1-Cq"
+FIELD_CH2_CQ = "CH2-Cq"
+FIELD_CH3_CQ = "CH3-Cq"
 
 # MLWH lighthouse samples table field names
 MLWH_LH_SAMPLE_ROOT_SAMPLE_ID ="root_sample_id"

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -10,9 +10,14 @@ FIELD_SOURCE = "source"
 FIELD_PLATE_BARCODE = "plate_barcode"
 FIELD_COG_BARCODE = "cog_barcode"
 FIELD_DATE_TESTED = "Date Tested"
+FIELD_CQ_1 = "CH1-Cq"
+FIELD_CQ_2 = "CH2-Cq"
+FIELD_CQ_3 = "CH3-Cq"
 
 # MLWH lighthouse samples table field names
 MLWH_LH_SAMPLE_ROOT_SAMPLE_ID ="root_sample_id"
 MLWH_LH_SAMPLE_COG_UK_ID = "cog_uk_id"
 MLWH_LH_SAMPLE_RNA_ID = "rna_id"
 MLWH_LH_SAMPLE_RESULT = "result"
+
+CT_LOWER_LIMIT = 30

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -10,9 +10,9 @@ FIELD_SOURCE = "source"
 FIELD_PLATE_BARCODE = "plate_barcode"
 FIELD_COG_BARCODE = "cog_barcode"
 FIELD_DATE_TESTED = "Date Tested"
-FIELD_CQ_1 = "CH1-Cq"
-FIELD_CQ_2 = "CH2-Cq"
-FIELD_CQ_3 = "CH3-Cq"
+FIELD_CQ_1 = "ch1_cq"
+FIELD_CQ_2 = "ch2_cq"
+FIELD_CQ_3 = "ch3_cq"
 
 # MLWH lighthouse samples table field names
 MLWH_LH_SAMPLE_ROOT_SAMPLE_ID ="root_sample_id"
@@ -20,4 +20,4 @@ MLWH_LH_SAMPLE_COG_UK_ID = "cog_uk_id"
 MLWH_LH_SAMPLE_RNA_ID = "rna_id"
 MLWH_LH_SAMPLE_RESULT = "result"
 
-CT_LOWER_LIMIT = 30
+CT_VALUE_LIMIT = 30

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -10,9 +10,9 @@ FIELD_SOURCE = "source"
 FIELD_PLATE_BARCODE = "plate_barcode"
 FIELD_COG_BARCODE = "cog_barcode"
 FIELD_DATE_TESTED = "Date Tested"
-FIELD_CQ_1 = "ch1_cq"
-FIELD_CQ_2 = "ch2_cq"
-FIELD_CQ_3 = "ch3_cq"
+FIELD_CH1_CQ = "ch1_cq"
+FIELD_CH2_CQ = "ch2_cq"
+FIELD_CH3_CQ = "ch3_cq"
 
 # MLWH lighthouse samples table field names
 MLWH_LH_SAMPLE_ROOT_SAMPLE_ID ="root_sample_id"
@@ -29,16 +29,16 @@ POSITIVE_SAMPLES_MONGODB_FILTER = {
   "$or": [
     {
       "$and": [
-          { FIELD_CQ_1: None },
-          { FIELD_CQ_2: None },
-          { FIELD_CQ_3: None }
+          { FIELD_CH1_CQ: None },
+          { FIELD_CH2_CQ: None },
+          { FIELD_CH3_CQ: None }
       ]
     },
     {
       "$or": [
-          { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} },
-          { FIELD_CQ_2: {"$lte": CT_VALUE_LIMIT} },
-          { FIELD_CQ_3: {"$lte": CT_VALUE_LIMIT} }
+          { FIELD_CH1_CQ: {"$lte": CT_VALUE_LIMIT} },
+          { FIELD_CH2_CQ: {"$lte": CT_VALUE_LIMIT} },
+          { FIELD_CH3_CQ: {"$lte": CT_VALUE_LIMIT} }
       ]
     }
   ]

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -1,3 +1,5 @@
+import re
+
 DUPLICATE_SAMPLES = "DuplicateSamples"
 NON_EXISTING_SAMPLE = "NonExistingSample"
 
@@ -25,6 +27,9 @@ CT_VALUE_LIMIT = 30
 POSITIVE_SAMPLES_MONGODB_FILTER = {
   FIELD_RESULT: {
     "$regex": "^positive", "$options": "i"
+  },
+  FIELD_ROOT_SAMPLE_ID: {
+    "$not": re.compile("^CBIQA_")
   },
   "$or": [
     {

--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -79,7 +79,7 @@ def get_centre_prefix(centre_name: str) -> Optional[str]:
 
         prefix = centre["prefix"]
 
-        logger.debug(f"Prefix for '{centre_name}' is '{prefix}")
+        logger.debug(f"Prefix for '{centre_name}' is '{prefix}'")
 
         return prefix
     except Exception as e:

--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -13,7 +13,8 @@ from lighthouse.constants import (
     FIELD_RESULT,
     FIELD_COORDINATE,
     FIELD_SOURCE,
-    FIELD_PLATE_BARCODE
+    FIELD_PLATE_BARCODE,
+    POSITIVE_SAMPLES_MONGODB_FILTER
 )
 from lighthouse.exceptions import (
     DataError,
@@ -109,8 +110,9 @@ def get_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
 
 
 def get_positive_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
+    merged_filter = { **{ FIELD_PLATE_BARCODE: plate_barcode }, **POSITIVE_SAMPLES_MONGODB_FILTER }
 
-    samples_for_barcode = find_samples({FIELD_PLATE_BARCODE: plate_barcode, FIELD_RESULT: "Positive"})
+    samples_for_barcode = find_samples(merged_filter)
 
     return samples_for_barcode
 

--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -2,6 +2,7 @@ import logging
 import re
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional
+import copy
 
 import requests
 from flask import current_app as app
@@ -91,7 +92,7 @@ def get_centre_prefix(centre_name: str) -> Optional[str]:
         raise DataError("Multiple centres with the same name")
 
 
-def find_samples(query: Dict[str, str]) -> Optional[List[Dict[str, Any]]]:
+def find_samples(query: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
     samples = app.data.driver.db.samples
 
     samples_for_barcode = list(samples.find(query))
@@ -110,9 +111,10 @@ def get_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
 
 
 def get_positive_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
-    merged_filter = { **{ FIELD_PLATE_BARCODE: plate_barcode }, **POSITIVE_SAMPLES_MONGODB_FILTER }
+    query_filter = copy.deepcopy(POSITIVE_SAMPLES_MONGODB_FILTER)
+    query_filter[FIELD_PLATE_BARCODE] = plate_barcode
 
-    samples_for_barcode = find_samples(merged_filter)
+    samples_for_barcode = find_samples(query_filter)
 
     return samples_for_barcode
 

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -33,7 +33,7 @@ from lighthouse.constants import (
     FIELD_CQ_1,
     FIELD_CQ_2,
     FIELD_CQ_3,
-    CT_LOWER_LIMIT
+    CT_VALUE_LIMIT
 )
 
 logger = logging.getLogger(__name__)
@@ -230,10 +230,27 @@ def get_all_positive_samples(samples):
     results = samples.find(
         filter={
             "$and": [
-                { FIELD_RESULT: { "$regex": "^positive", "$options": "i" } },
-                { "$or": [ { FIELD_CQ_1: None }, { FIELD_CQ_1: {"$gte": CT_LOWER_LIMIT} } ] },
-                { "$or": [ { FIELD_CQ_2: None }, { FIELD_CQ_2: {"$gte": CT_LOWER_LIMIT} } ] },
-                { "$or": [ { FIELD_CQ_3: None }, { FIELD_CQ_3: {"$gte": CT_LOWER_LIMIT} } ] }
+                {
+                    FIELD_RESULT: { "$regex": "^positive", "$options": "i" }
+                },
+                {
+                    "$or": [
+                        {
+                            "$and": [
+                                { FIELD_CQ_1: None },
+                                { FIELD_CQ_2: None },
+                                { FIELD_CQ_3: None }
+                            ]
+                        },
+                        {
+                            "$or": [
+                                { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} },
+                                { FIELD_CQ_2: {"$lte": CT_VALUE_LIMIT} },
+                                { FIELD_CQ_3: {"$lte": CT_VALUE_LIMIT} }
+                            ]
+                        }
+                    ]
+                },
             ]
         },
         projection={

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -29,7 +29,11 @@ from lighthouse.constants import (
     FIELD_ROOT_SAMPLE_ID,
     FIELD_RESULT,
     FIELD_DATE_TESTED,
-    FIELD_COORDINATE
+    FIELD_COORDINATE,
+    FIELD_CQ_1,
+    FIELD_CQ_2,
+    FIELD_CQ_3,
+    CT_LOWER_LIMIT
 )
 
 logger = logging.getLogger(__name__)
@@ -224,7 +228,14 @@ def get_all_positive_samples(samples):
     logger.debug("Getting all positive samples")
     # filtering using case insensitive regex to catch "Positive" and "positive"
     results = samples.find(
-        filter={FIELD_RESULT: {"$regex": "^positive", "$options": "i"}},
+        filter={
+            "$and": [
+                { FIELD_RESULT: { "$regex": "^positive", "$options": "i" } },
+                { "$or": [ { FIELD_CQ_1: None }, { FIELD_CQ_1: {"$gte": CT_LOWER_LIMIT} } ] },
+                { "$or": [ { FIELD_CQ_2: None }, { FIELD_CQ_2: {"$gte": CT_LOWER_LIMIT} } ] },
+                { "$or": [ { FIELD_CQ_3: None }, { FIELD_CQ_3: {"$gte": CT_LOWER_LIMIT} } ] }
+            ]
+        },
         projection={
             "_id": False,
             FIELD_SOURCE: True,

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -33,7 +33,8 @@ from lighthouse.constants import (
     FIELD_CQ_1,
     FIELD_CQ_2,
     FIELD_CQ_3,
-    CT_VALUE_LIMIT
+    CT_VALUE_LIMIT,
+    POSITIVE_SAMPLES_MONGODB_FILTER
 )
 
 logger = logging.getLogger(__name__)
@@ -228,32 +229,8 @@ def get_all_positive_samples(samples):
     logger.debug("Getting all positive samples")
     # filtering using case insensitive regex to catch "Positive" and "positive"
     results = samples.find(
-        filter={
-            "$and": [
-                {
-                    FIELD_RESULT: { "$regex": "^positive", "$options": "i" }
-                },
-                {
-                    "$or": [
-                        {
-                            "$and": [
-                                { FIELD_CQ_1: None },
-                                { FIELD_CQ_2: None },
-                                { FIELD_CQ_3: None }
-                            ]
-                        },
-                        {
-                            "$or": [
-                                { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} },
-                                { FIELD_CQ_2: {"$lte": CT_VALUE_LIMIT} },
-                                { FIELD_CQ_3: {"$lte": CT_VALUE_LIMIT} }
-                            ]
-                        }
-                    ]
-                },
-            ]
-        },
-        projection={
+        filter = POSITIVE_SAMPLES_MONGODB_FILTER,
+        projection = {
             "_id": False,
             FIELD_SOURCE: True,
             FIELD_PLATE_BARCODE: True,

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -30,9 +30,6 @@ from lighthouse.constants import (
     FIELD_RESULT,
     FIELD_DATE_TESTED,
     FIELD_COORDINATE,
-    FIELD_CQ_1,
-    FIELD_CQ_2,
-    FIELD_CQ_3,
     CT_VALUE_LIMIT,
     POSITIVE_SAMPLES_MONGODB_FILTER
 )

--- a/tests/blueprints/test_plates.py
+++ b/tests/blueprints/test_plates.py
@@ -20,7 +20,7 @@ def test_post_plates_endpoint_successful(app, client, samples, mocked_responses,
         )
         assert response.status_code == HTTPStatus.OK
         assert response.json == {
-            "data": {"plate_barcode": "123", "centre": "TS1", "number_of_positives": 4}
+            "data": {"plate_barcode": "123", "centre": "TS1", "number_of_positives": 3}
         }
 
 
@@ -41,7 +41,7 @@ def test_post_plates_endpoint_no_positive_samples(app, client):
 def test_post_plates_endpoint_add_cog_barcodes_failed(
     app, client, samples, centres, mocked_responses
 ):
-    baracoda_url = f"http://{app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=4"
+    baracoda_url = f"http://{app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=3"
 
     mocked_responses.add(
         responses.POST, baracoda_url, status=HTTPStatus.BAD_REQUEST,

--- a/tests/blueprints/test_plates.py
+++ b/tests/blueprints/test_plates.py
@@ -20,7 +20,7 @@ def test_post_plates_endpoint_successful(app, client, samples, mocked_responses,
         )
         assert response.status_code == HTTPStatus.OK
         assert response.json == {
-            "data": {"plate_barcode": "123", "centre": "TS1", "number_of_positives": 1}
+            "data": {"plate_barcode": "123", "centre": "TS1", "number_of_positives": 4}
         }
 
 
@@ -41,7 +41,7 @@ def test_post_plates_endpoint_no_positive_samples(app, client):
 def test_post_plates_endpoint_add_cog_barcodes_failed(
     app, client, samples, centres, mocked_responses
 ):
-    baracoda_url = f"http://{app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=1"
+    baracoda_url = f"http://{app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=4"
 
     mocked_responses.add(
         responses.POST, baracoda_url, status=HTTPStatus.BAD_REQUEST,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,8 @@ from .data.fixture_data import (
     SAMPLES_FOR_MLWH_UPDATE,
     COG_UK_IDS,
     MLWH_SEED_SAMPLES,
-    MLWH_SEED_SAMPLES_MULTIPLE
+    MLWH_SEED_SAMPLES_MULTIPLE,
+    SAMPLES_CT_VALUES
 )
 
 from lighthouse.helpers.mlwh_db import (
@@ -113,6 +114,19 @@ def samples(app):
 
     #  yield a copy of that the test change it however it wants
     yield copy.deepcopy(SAMPLES)
+
+    # clear up after the fixture is used
+    with app.app_context():
+        samples_collection.delete_many({})
+
+@pytest.fixture
+def samples_ct_values(app):
+    with app.app_context():
+        samples_collection = app.data.driver.db.samples
+        _ = samples_collection.insert_many(SAMPLES_CT_VALUES)
+
+    #  yield a copy of that the test change it however it wants
+    yield copy.deepcopy(SAMPLES_CT_VALUES)
 
     # clear up after the fixture is used
     with app.app_context():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,8 @@ from .data.fixture_data import (
     COG_UK_IDS,
     MLWH_SEED_SAMPLES,
     MLWH_SEED_SAMPLES_MULTIPLE,
-    SAMPLES_CT_VALUES
+    SAMPLES_CT_VALUES,
+    SAMPLES_DIFFERENT_PLATES
 )
 
 from lighthouse.helpers.mlwh_db import (
@@ -114,6 +115,19 @@ def samples(app):
 
     #  yield a copy of that the test change it however it wants
     yield copy.deepcopy(SAMPLES)
+
+    # clear up after the fixture is used
+    with app.app_context():
+        samples_collection.delete_many({})
+
+@pytest.fixture
+def samples_different_plates(app):
+    with app.app_context():
+        samples_collection = app.data.driver.db.samples
+        _ = samples_collection.insert_many(SAMPLES_DIFFERENT_PLATES)
+
+    #  yield a copy of that the test change it however it wants
+    yield copy.deepcopy(SAMPLES_DIFFERENT_PLATES)
 
     # clear up after the fixture is used
     with app.app_context():

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -8,9 +8,9 @@ from lighthouse.constants import (
     FIELD_COORDINATE,
     FIELD_SOURCE,
     FIELD_PLATE_BARCODE,
-    FIELD_CQ_1,
-    FIELD_CQ_2,
-    FIELD_CQ_3,
+    FIELD_CH1_CQ,
+    FIELD_CH2_CQ,
+    FIELD_CH3_CQ,
     MLWH_LH_SAMPLE_ROOT_SAMPLE_ID,
     MLWH_LH_SAMPLE_RNA_ID,
     MLWH_LH_SAMPLE_RESULT
@@ -137,9 +137,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "nop",
         FIELD_ROOT_SAMPLE_ID: "MCM005",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: 5,
-        FIELD_CQ_2: 6,
-        FIELD_CQ_3: 7
+        FIELD_CH1_CQ: 5,
+        FIELD_CH2_CQ: 6,
+        FIELD_CH3_CQ: 7
     },
     { # positive, with high Ct values
         FIELD_COORDINATE: "F01",
@@ -149,9 +149,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "qrs",
         FIELD_ROOT_SAMPLE_ID: "MCM006",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: 40,
-        FIELD_CQ_2: 41,
-        FIELD_CQ_3: 42
+        FIELD_CH1_CQ: 40,
+        FIELD_CH2_CQ: 41,
+        FIELD_CH3_CQ: 42
     },
     { # positive, with mix of Ct values
         FIELD_COORDINATE: "G01",
@@ -161,9 +161,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "tuv",
         FIELD_ROOT_SAMPLE_ID: "MCM007",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: 5,
-        FIELD_CQ_2: None,
-        FIELD_CQ_3: 45
+        FIELD_CH1_CQ: 5,
+        FIELD_CH2_CQ: None,
+        FIELD_CH3_CQ: 45
     }
 ]
 
@@ -185,7 +185,7 @@ SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "def",
         FIELD_ROOT_SAMPLE_ID: "MCM002",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: None
+        FIELD_CH1_CQ: None
     },
     { # Ct is less than limit
         FIELD_COORDINATE: "C01",
@@ -195,7 +195,7 @@ SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "ghi",
         FIELD_ROOT_SAMPLE_ID: "MCM003",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: 5
+        FIELD_CH1_CQ: 5
     },
     { # Ct is greater than limit
         FIELD_COORDINATE: "C01",
@@ -205,7 +205,7 @@ SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "jkl",
         FIELD_ROOT_SAMPLE_ID: "MCM004",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CQ_1: 45
+        FIELD_CH1_CQ: 45
     }
 ]
 

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -92,7 +92,7 @@ LOTS_OF_SAMPLES_DECLARATIONS_PAYLOAD: List[Dict[str, str]] = [
     for i in range(0, MAX_SAMPLES)
 ]
 
-SAMPLES: List[Dict[str, str]] = [
+SAMPLES: List[Dict[str, Any]] = [
     { # a positive result, no Ct values
         FIELD_COORDINATE: "A01",
         FIELD_SOURCE: "test1",
@@ -167,7 +167,7 @@ SAMPLES: List[Dict[str, str]] = [
     }
 ]
 
-SAMPLES_CT_VALUES: List[Dict[str, str]] = [
+SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
     { # Ct is missing
         FIELD_COORDINATE: "A01",
         FIELD_SOURCE: "test1",

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -137,9 +137,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "nop",
         FIELD_ROOT_SAMPLE_ID: "MCM005",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CH1_CQ: 5,
-        FIELD_CH2_CQ: 6,
-        FIELD_CH3_CQ: 7
+        FIELD_CH1_CQ: 5.12345678,
+        FIELD_CH2_CQ: 6.12345678,
+        FIELD_CH3_CQ: 7.12345678
     },
     { # positive, with high Ct values
         FIELD_COORDINATE: "F01",
@@ -149,9 +149,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "qrs",
         FIELD_ROOT_SAMPLE_ID: "MCM006",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CH1_CQ: 40,
-        FIELD_CH2_CQ: 41,
-        FIELD_CH3_CQ: 42
+        FIELD_CH1_CQ: 40.12345678,
+        FIELD_CH2_CQ: 41.12345678,
+        FIELD_CH3_CQ: 42.12345678
     },
     { # positive, with mix of Ct values
         FIELD_COORDINATE: "G01",
@@ -161,9 +161,9 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "tuv",
         FIELD_ROOT_SAMPLE_ID: "MCM007",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CH1_CQ: 5,
+        FIELD_CH1_CQ: 5.12345678,
         FIELD_CH2_CQ: None,
-        FIELD_CH3_CQ: 45
+        FIELD_CH3_CQ: 45.12345678
     }
 ]
 
@@ -195,7 +195,7 @@ SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "ghi",
         FIELD_ROOT_SAMPLE_ID: "MCM003",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CH1_CQ: 5
+        FIELD_CH1_CQ: 5.12345678
     },
     { # Ct is greater than limit
         FIELD_COORDINATE: "C01",
@@ -205,7 +205,7 @@ SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
         FIELD_COG_BARCODE: "jkl",
         FIELD_ROOT_SAMPLE_ID: "MCM004",
         FIELD_RNA_ID: "rna_1",
-        FIELD_CH1_CQ: 45
+        FIELD_CH1_CQ: 45.12345678
     }
 ]
 

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -8,6 +8,9 @@ from lighthouse.constants import (
     FIELD_COORDINATE,
     FIELD_SOURCE,
     FIELD_PLATE_BARCODE,
+    FIELD_CQ_1,
+    FIELD_CQ_2,
+    FIELD_CQ_3,
     MLWH_LH_SAMPLE_ROOT_SAMPLE_ID,
     MLWH_LH_SAMPLE_RNA_ID,
     MLWH_LH_SAMPLE_RESULT
@@ -90,7 +93,7 @@ LOTS_OF_SAMPLES_DECLARATIONS_PAYLOAD: List[Dict[str, str]] = [
 ]
 
 SAMPLES: List[Dict[str, str]] = [
-    {
+    { # a positive result, no Ct values
         FIELD_COORDINATE: "A01",
         FIELD_SOURCE: "test1",
         FIELD_RESULT: "Positive",
@@ -99,7 +102,7 @@ SAMPLES: List[Dict[str, str]] = [
         FIELD_ROOT_SAMPLE_ID: "MCM001",
         FIELD_RNA_ID: "rna_1"
     },
-    {
+    { # a negative result
         FIELD_COORDINATE: "B01",
         FIELD_SOURCE: "test1",
         FIELD_RESULT: "Negative",
@@ -108,7 +111,7 @@ SAMPLES: List[Dict[str, str]] = [
         FIELD_ROOT_SAMPLE_ID: "MCM002",
         FIELD_RNA_ID: "rna_1"
     },
-    {
+    { # a void result
         FIELD_COORDINATE: "C01",
         FIELD_SOURCE: "test1",
         FIELD_RESULT: "Void",
@@ -117,6 +120,93 @@ SAMPLES: List[Dict[str, str]] = [
         FIELD_ROOT_SAMPLE_ID: "MCM003",
         FIELD_RNA_ID: "rna_1"
     },
+    { # a 'limit of detection' result
+        FIELD_COORDINATE: "D01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "limit of detection",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "klm",
+        FIELD_ROOT_SAMPLE_ID: "MCM004",
+        FIELD_RNA_ID: "rna_1"
+    },
+    { # positive, with low Ct values
+        FIELD_COORDINATE: "E01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "nop",
+        FIELD_ROOT_SAMPLE_ID: "MCM005",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: 5,
+        FIELD_CQ_2: 6,
+        FIELD_CQ_3: 7
+    },
+    { # positive, with high Ct values
+        FIELD_COORDINATE: "F01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "qrs",
+        FIELD_ROOT_SAMPLE_ID: "MCM006",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: 40,
+        FIELD_CQ_2: 41,
+        FIELD_CQ_3: 42
+    },
+    { # positive, with mix of Ct values
+        FIELD_COORDINATE: "G01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "tuv",
+        FIELD_ROOT_SAMPLE_ID: "MCM007",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: 5,
+        FIELD_CQ_2: None,
+        FIELD_CQ_3: 45
+    }
+]
+
+SAMPLES_CT_VALUES: List[Dict[str, str]] = [
+    { # Ct is missing
+        FIELD_COORDINATE: "A01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "abc",
+        FIELD_ROOT_SAMPLE_ID: "MCM001",
+        FIELD_RNA_ID: "rna_1"
+    },
+    { # Ct is null
+        FIELD_COORDINATE: "B01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Negative",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "def",
+        FIELD_ROOT_SAMPLE_ID: "MCM002",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: None
+    },
+    { # Ct is less than limit
+        FIELD_COORDINATE: "C01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Negative",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "ghi",
+        FIELD_ROOT_SAMPLE_ID: "MCM003",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: 5
+    },
+    { # Ct is greater than limit
+        FIELD_COORDINATE: "C01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Negative",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "jkl",
+        FIELD_ROOT_SAMPLE_ID: "MCM004",
+        FIELD_RNA_ID: "rna_1",
+        FIELD_CQ_1: 45
+    }
 ]
 
 SAMPLES_NO_DECLARATION: List[Dict[str, str]] = [

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -277,6 +277,21 @@ MLWH_SEED_SAMPLES: List[Dict[str, str]] = [
         MLWH_LH_SAMPLE_ROOT_SAMPLE_ID: 'MCM001',
         MLWH_LH_SAMPLE_RNA_ID: 'rna_1',
         MLWH_LH_SAMPLE_RESULT: 'Positive'
+    },
+    {
+        MLWH_LH_SAMPLE_ROOT_SAMPLE_ID: 'MCM005',
+        MLWH_LH_SAMPLE_RNA_ID: 'rna_1',
+        MLWH_LH_SAMPLE_RESULT: 'Positive'
+    },
+    {
+        MLWH_LH_SAMPLE_ROOT_SAMPLE_ID: 'MCM006',
+        MLWH_LH_SAMPLE_RNA_ID: 'rna_1',
+        MLWH_LH_SAMPLE_RESULT: 'Positive'
+    },
+    {
+        MLWH_LH_SAMPLE_ROOT_SAMPLE_ID: 'MCM007',
+        MLWH_LH_SAMPLE_RNA_ID: 'rna_1',
+        MLWH_LH_SAMPLE_RESULT: 'Positive'
     }
 ]
 

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -164,6 +164,15 @@ SAMPLES: List[Dict[str, Any]] = [
         FIELD_CH1_CQ: 5.12345678,
         FIELD_CH2_CQ: None,
         FIELD_CH3_CQ: 45.12345678
+    },
+    { # positive, with disallowed Root Sample ID
+        FIELD_COORDINATE: "A02",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "wxy",
+        FIELD_ROOT_SAMPLE_ID: "CBIQA_MCM008",
+        FIELD_RNA_ID: "rna_1"
     }
 ]
 

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -167,6 +167,27 @@ SAMPLES: List[Dict[str, Any]] = [
     }
 ]
 
+SAMPLES_DIFFERENT_PLATES: List[Dict[str, Any]] = [
+    {
+        FIELD_COORDINATE: "A01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "123",
+        FIELD_COG_BARCODE: "abc",
+        FIELD_ROOT_SAMPLE_ID: "MCM001",
+        FIELD_RNA_ID: "rna_1"
+    },
+    {
+        FIELD_COORDINATE: "A01",
+        FIELD_SOURCE: "test1",
+        FIELD_RESULT: "Positive",
+        FIELD_PLATE_BARCODE: "456",
+        FIELD_COG_BARCODE: "def",
+        FIELD_ROOT_SAMPLE_ID: "MCM002",
+        FIELD_RNA_ID: "rna_2"
+    }
+]
+
 SAMPLES_CT_VALUES: List[Dict[str, Any]] = [
     { # Ct is missing
         FIELD_COORDINATE: "A01",

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -30,12 +30,12 @@ from lighthouse.helpers.plates import (
 
 def test_add_cog_barcodes(app, centres, samples, mocked_responses):
     with app.app_context():
-        baracoda_url = f"http://{current_app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=3"
+        baracoda_url = f"http://{current_app.config['BARACODA_URL']}/barcodes_group/TS1/new?count={len(samples)}"
 
         # remove the cog_barcode key and value from the samples fixture before testing
         map(lambda sample: sample.pop(FIELD_COG_BARCODE), samples)
 
-        cog_barcodes = ("123", "456", "789")
+        cog_barcodes = ("123", "456", "789", "101", "131", "161", "192")
 
         # update the 'cog_barcode' tuple when adding more samples to the fixture data
         assert len(cog_barcodes) == len(samples)
@@ -93,6 +93,34 @@ def test_create_post_body(app, samples):
                                 "sample_description": "MCM003",
                             }
                         },
+                        "D01": {
+                            "content": {
+                                "phenotype": "limit of detection",
+                                "supplier_name": "klm",
+                                "sample_description": "MCM004",
+                            }
+                        },
+                        "E01": {
+                            "content": {
+                                "phenotype": "positive",
+                                "supplier_name": "nop",
+                                "sample_description": "MCM005",
+                            }
+                        },
+                        "F01": {
+                            "content": {
+                                "phenotype": "positive",
+                                "supplier_name": "qrs",
+                                "sample_description": "MCM006",
+                            }
+                        },
+                        "G01": {
+                            "content": {
+                                "phenotype": "positive",
+                                "supplier_name": "tuv",
+                                "sample_description": "MCM007",
+                            }
+                        }
                     },
                 },
             }
@@ -102,11 +130,11 @@ def test_create_post_body(app, samples):
 
 def test_get_samples(app, samples):
     with app.app_context():
-        assert len(get_samples("123")) == 3
+        assert len(get_samples("123")) == 7
 
 def test_get_positive_samples(app, samples):
     with app.app_context():
-        assert len(get_positive_samples("123")) == 1
+        assert len(get_positive_samples("123")) == 4
 
 def test_update_mlwh_with_cog_uk_ids(app, mlwh_lh_samples_multiple, samples_for_mlwh_update, cog_uk_ids, sql_engine):
     with app.app_context():

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -136,6 +136,10 @@ def test_get_positive_samples(app, samples):
     with app.app_context():
         assert len(get_positive_samples("123")) == 3
 
+def test_get_positive_samples_different_plates(app, samples_different_plates):
+    with app.app_context():
+        assert len(get_positive_samples("123")) == 1
+
 def test_update_mlwh_with_cog_uk_ids(app, mlwh_lh_samples_multiple, samples_for_mlwh_update, cog_uk_ids, sql_engine):
     with app.app_context():
         # check that the samples already exist in the MLWH db but do not have cog uk ids

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -35,7 +35,7 @@ def test_add_cog_barcodes(app, centres, samples, mocked_responses):
         # remove the cog_barcode key and value from the samples fixture before testing
         map(lambda sample: sample.pop(FIELD_COG_BARCODE), samples)
 
-        cog_barcodes = ("123", "456", "789", "101", "131", "161", "192")
+        cog_barcodes = ("123", "456", "789", "101", "131", "161", "192", "222")
 
         # update the 'cog_barcode' tuple when adding more samples to the fixture data
         assert len(cog_barcodes) == len(samples)
@@ -120,6 +120,13 @@ def test_create_post_body(app, samples):
                                 "supplier_name": "tuv",
                                 "sample_description": "MCM007",
                             }
+                        },
+                        "A02": {
+                            "content": {
+                                "phenotype": "positive",
+                                "supplier_name": "wxy",
+                                "sample_description": "CBIQA_MCM008",
+                            }
                         }
                     },
                 },
@@ -130,7 +137,7 @@ def test_create_post_body(app, samples):
 
 def test_get_samples(app, samples):
     with app.app_context():
-        assert len(get_samples("123")) == 7
+        assert len(get_samples("123")) == 8
 
 def test_get_positive_samples(app, samples):
     with app.app_context():

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -134,7 +134,7 @@ def test_get_samples(app, samples):
 
 def test_get_positive_samples(app, samples):
     with app.app_context():
-        assert len(get_positive_samples("123")) == 4
+        assert len(get_positive_samples("123")) == 3
 
 def test_update_mlwh_with_cog_uk_ids(app, mlwh_lh_samples_multiple, samples_for_mlwh_update, cog_uk_ids, sql_engine):
     with app.app_context():

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -23,7 +23,9 @@ from lighthouse.constants import (
     FIELD_ROOT_SAMPLE_ID,
     FIELD_RESULT,
     FIELD_PLATE_BARCODE,
-    FIELD_SOURCE
+    FIELD_SOURCE,
+    FIELD_CQ_1,
+    CT_VALUE_LIMIT
 )
 
 def test_get_new_report_name_and_path(app, freezer):
@@ -98,13 +100,26 @@ def test_get_all_positive_samples(app, freezer, samples):
         samples = app.data.driver.db.samples
         positive_samples = get_all_positive_samples(samples)
 
-        assert len(positive_samples) == 1
+        assert len(positive_samples) == 3
         assert positive_samples.at[0,FIELD_ROOT_SAMPLE_ID] == 'MCM001'
         assert positive_samples.at[0,FIELD_RESULT] == 'Positive'
         assert positive_samples.at[0,FIELD_SOURCE] == 'test1'
         assert positive_samples.at[0,FIELD_PLATE_BARCODE] == '123'
         assert positive_samples.at[0,FIELD_COORDINATE] == 'A1'
         assert positive_samples.at[0,'plate and well'] == '123:A1'
+
+        assert positive_samples.at[1,FIELD_ROOT_SAMPLE_ID] == 'MCM005'
+        assert positive_samples.at[2,FIELD_ROOT_SAMPLE_ID] == 'MCM007'
+
+
+def test_query_by_ct_limit(app, freezer, samples_ct_values):
+    # Just testing how mongo queries work with 'less than' comparisons and nulls
+    with app.app_context():
+        samples = app.data.driver.db.samples
+        ct_less_than_limit = samples.count_documents( { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} } )
+
+        assert ct_less_than_limit == 1 # 'MCM003'
+
 
 def test_map_labware_to_location_labwhere_error(app, freezer, labwhere_samples_error):
     # mocks response from get_locations_from_labwhere() with labwhere_samples_error

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -24,7 +24,7 @@ from lighthouse.constants import (
     FIELD_RESULT,
     FIELD_PLATE_BARCODE,
     FIELD_SOURCE,
-    FIELD_CQ_1,
+    FIELD_CH1_CQ,
     CT_VALUE_LIMIT
 )
 
@@ -116,7 +116,7 @@ def test_query_by_ct_limit(app, freezer, samples_ct_values):
     # Just testing how mongo queries work with 'less than' comparisons and nulls
     with app.app_context():
         samples = app.data.driver.db.samples
-        ct_less_than_limit = samples.count_documents( { FIELD_CQ_1: {"$lte": CT_VALUE_LIMIT} } )
+        ct_less_than_limit = samples.count_documents( { FIELD_CH1_CQ: {"$lte": CT_VALUE_LIMIT} } )
 
         assert ct_less_than_limit == 1 # 'MCM003'
 

--- a/tests/validators/test_samples_declarations_validators.py
+++ b/tests/validators/test_samples_declarations_validators.py
@@ -16,8 +16,8 @@ def test_find_duplicates():
 def test_find_non_exist_samples(app, samples):
     with app.app_context():
         assert find_non_exist_samples(["MCM001", "MCM003"]) == []
-        assert find_non_exist_samples(["MCM004"]) == ["MCM004"]
-        assert find_non_exist_samples(["MCM004", "MCM003"]) == ["MCM004"]
+        assert find_non_exist_samples(["MCM100"]) == ["MCM100"]
+        assert find_non_exist_samples(["MCM100", "MCM003"]) == ["MCM100"]
         assert sorted(find_non_exist_samples(["a", "b", "c"])) == sorted(["a", "b", "c"])
 
 


### PR DESCRIPTION
I had to change a bunch of unrelated tests because I added to the 'samples' fixture data.

Most important changes for this story are in:
- helpers/reports.py (GPL-659)
- tests/helpers/test_reports_helpers.py (GPL-659)
- helpers/plates.py (GPL-nnn)
- tests/helpers/test_plates_helpers.py (GPL-nnn)
- constants (both)
- fixture_data.py (both)