### PR TITLE
updated cherrypicked-plates/create endpoint to now use GET

### DIFF
--- a/lighthouse/blueprints/cherrypicked_plates.py
+++ b/lighthouse/blueprints/cherrypicked_plates.py
@@ -28,14 +28,18 @@ bp = Blueprint("cherrypicked-plates", __name__)
 CORS(bp)
 
 
-@bp.route("/cherrypicked-plates/create", methods=["POST"])
+@bp.route("/cherrypicked-plates/create", methods=["GET"])
 def create_plate_from_barcode() -> Tuple[Dict[str, Any], int]:
+
+    invalid_url = {"errors": ["GET request needs 'barcode' in url"]}, HTTPStatus.BAD_REQUEST
     try:
-        barcode = request.get_json()["barcode"]
+        barcode = request.args.get('barcode', '')
+        if len(barcode) == 0:
+            return invalid_url
         logger.info(f"Attempting to create a plate in SS from barcode: {barcode}")
     except (KeyError, TypeError) as e:
         logger.exception(e)
-        return {"errors": ["POST request needs 'barcode' in body"]}, HTTPStatus.BAD_REQUEST
+        return invalid_url
 
     try:
         dart_samples = find_dart_source_samples_rows(barcode)

--- a/lighthouse/blueprints/cherrypicked_plates.py
+++ b/lighthouse/blueprints/cherrypicked_plates.py
@@ -31,15 +31,14 @@ CORS(bp)
 @bp.route("/cherrypicked-plates/create", methods=["GET"])
 def create_plate_from_barcode() -> Tuple[Dict[str, Any], int]:
 
-    invalid_url = {"errors": ["GET request needs 'barcode' in url"]}, HTTPStatus.BAD_REQUEST
     try:
         barcode = request.args.get('barcode', '')
         if len(barcode) == 0:
-            return invalid_url
+            return invalid_url_error()
         logger.info(f"Attempting to create a plate in SS from barcode: {barcode}")
     except (KeyError, TypeError) as e:
         logger.exception(e)
-        return invalid_url
+        return invalid_url_error()
 
     try:
         dart_samples = find_dart_source_samples_rows(barcode)
@@ -111,3 +110,6 @@ def create_plate_from_barcode() -> Tuple[Dict[str, Any], int]:
     except Exception as e:
         logger.exception(e)
         return {"errors": [type(e).__name__]}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+def invalid_url_error():
+    return {"errors": ["GET request needs 'barcode' in url"]}, HTTPStatus.BAD_REQUEST

--- a/tests/blueprints/test_cherrypicked_plates.py
+++ b/tests/blueprints/test_cherrypicked_plates.py
@@ -4,7 +4,7 @@ import json
 import responses  # type: ignore
 
 
-def test_post_cherrypicked_plates_endpoint_successful(
+def test_get_cherrypicked_plates_endpoint_successful(
     app, client, dart_samples_for_bp_test, samples_with_lab_id, mocked_responses, mlwh_lh_samples
 ):
     with patch(
@@ -20,9 +20,8 @@ def test_post_cherrypicked_plates_endpoint_successful(
             body=body,
             status=HTTPStatus.OK,
         )
-        response = client.post(
-            "/cherrypicked-plates/create",
-            data=json.dumps({"barcode": "plate_1"}),
+        response = client.get(
+            "/cherrypicked-plates/create?barcode=plate_1",
             content_type="application/json",
         )
 
@@ -32,29 +31,28 @@ def test_post_cherrypicked_plates_endpoint_successful(
         }
 
 
-def test_post_cherrypicked_plates_endpoint_no_barcode_in_request(
+def test_get_cherrypicked_plates_endpoint_no_barcode_in_request(
     app, client, dart_samples_for_bp_test, samples_with_lab_id
 ):
-    response = client.post(
+    response = client.get(
         "/cherrypicked-plates/create",
-        data=json.dumps({}),
         content_type="application/json",
     )
+
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.json == {"errors": ["POST request needs 'barcode' in body"]}
+    assert response.json == {"errors": ["GET request needs 'barcode' in url"]}
 
 
-def test_post_cherrypicked_plates_endpoint_no_positive_samples(app, client):
-    response = client.post(
-        "/cherrypicked-plates/create",
-        data=json.dumps({"barcode": "plate_1"}),
+def test_get_cherrypicked_plates_endpoint_no_positive_samples(app, client):
+    response = client.get(
+        "/cherrypicked-plates/create?barcode=plate_1",
         content_type="application/json",
     )
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json == {"errors": ["No samples for this barcode: plate_1"]}
 
 
-def test_post_plates_endpoint_add_cog_barcodes_failed(
+def test_get_cherrypicked_plates_endpoint_add_cog_barcodes_failed(
     app, client, dart_samples_for_bp_test, samples_with_lab_id, centres, mocked_responses
 ):
     baracoda_url = f"http://{app.config['BARACODA_URL']}/barcodes_group/TS1/new?count=2"
@@ -65,16 +63,15 @@ def test_post_plates_endpoint_add_cog_barcodes_failed(
         status=HTTPStatus.BAD_REQUEST,
     )
 
-    response = client.post(
-        "/cherrypicked-plates/create",
-        data=json.dumps({"barcode": "plate_1"}),
+    response = client.get(
+        "/cherrypicked-plates/create?barcode=plate_1",
         content_type="application/json",
     )
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json == {"errors": ["Failed to add COG barcodes to plate: plate_1"]}
 
 
-def test_post_plates_endpoint_ss_failure(
+def test_get_cherrypicked_plates_endpoint_ss_failure(
     app, client, dart_samples_for_bp_test, samples_with_lab_id, mocked_responses
 ):
     with patch(
@@ -91,16 +88,15 @@ def test_post_plates_endpoint_ss_failure(
             status=HTTPStatus.UNPROCESSABLE_ENTITY,
         )
 
-        response = client.post(
-            "/cherrypicked-plates/create",
-            data=json.dumps({"barcode": "plate_1"}),
+        response = client.get(
+            "/cherrypicked-plates/create?barcode=plate_1",
             content_type="application/json",
         )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json == {"errors": ["The barcode 'plate_1' is not a recognised format."]}
 
 
-def test_post_plates_mlwh_update_failure(
+def test_get_cherrypicked_plates_mlwh_update_failure(
     app, client, dart_samples_for_bp_test, samples_with_lab_id, mocked_responses
 ):
     with patch(
@@ -121,9 +117,8 @@ def test_post_plates_mlwh_update_failure(
                 status=HTTPStatus.OK,
             )
 
-            response = client.post(
-                "/cherrypicked-plates/create",
-                data=json.dumps({"barcode": "plate_1"}),
+            response = client.get(
+                "/cherrypicked-plates/create?barcode=plate_1",
                 content_type="application/json",
             )
             assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
@@ -144,9 +139,8 @@ def test_post_plates_endpoint_unmatched_sample_data(app, client, dart_samples_fo
             side_effect=Exception("Boom!"),
         ):
             barcode = "plate_1"
-            response = client.post(
-                "/cherrypicked-plates/create",
-                data=json.dumps({"barcode": barcode}),
+            response = client.get(
+                "/cherrypicked-plates/create?barcode=plate_1",
                 content_type="application/json",
             )
 
@@ -160,9 +154,8 @@ def test_post_plates_endpoint_missing_dart_data(app, client):
         return_value=[],
     ):
         barcode = "plate_1"
-        response = client.post(
-            "/cherrypicked-plates/create",
-            data=json.dumps({"barcode": barcode}),
+        response = client.get(
+            "/cherrypicked-plates/create?barcode=plate_1",
             content_type="application/json",
         )
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION


Closes #

Changes proposed in this pull request:

*Cherrypicked-plates/create now uses GET instead of POST 
*Updated tests
* ...
