### PR TITLE
Issue147/gpl 726 whats of value in this lh box then

### DIFF
--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -125,7 +125,7 @@ def find_samples(query: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
     return samples_for_barcode
 
 
-def count_samples(query: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+def count_samples(query: Dict[str, Any]) -> int:
     samples = app.data.driver.db.samples
 
     return samples.count_documents(query)

--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -100,6 +100,12 @@ def find_samples(query: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
     return samples_for_barcode
 
 
+def count_samples(query: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+    samples = app.data.driver.db.samples
+
+    return samples.count_documents(query)
+
+
 # TODO: remove once we are sure that we dont need anything other than positives
 def get_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
 
@@ -111,10 +117,22 @@ def get_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
 def get_positive_samples(plate_barcode: str) -> Optional[List[Dict[str, Any]]]:
     query_filter = copy.deepcopy(POSITIVE_SAMPLES_MONGODB_FILTER)
     query_filter[FIELD_PLATE_BARCODE] = plate_barcode
-
     samples_for_barcode = find_samples(query_filter)
 
     return samples_for_barcode
+
+
+def count_positive_samples(plate_barcode: str) -> int:
+    query_filter = copy.deepcopy(POSITIVE_SAMPLES_MONGODB_FILTER)
+    query_filter[FIELD_PLATE_BARCODE] = plate_barcode
+    samples_for_barcode = count_samples(query_filter)
+
+    return samples_for_barcode
+
+
+def has_sample_data(plate_barcode: str) -> bool:
+    sample_count = count_samples({FIELD_PLATE_BARCODE: plate_barcode})
+    return sample_count > 0
 
 
 def confirm_centre(samples: List[Dict[str, str]]) -> str:

--- a/tests/blueprints/test_plates.py
+++ b/tests/blueprints/test_plates.py
@@ -126,7 +126,7 @@ def test_post_plates_mlwh_update_failure(app, client, samples, mocked_responses)
             }
 
 
-def test_get_plates_endpoint_successful(app, client, samples, mocked_responses, mlwh_lh_samples):
+def test_get_plates_endpoint_successful(app, client, samples, mocked_responses):
     response = client.get(
         "/plates?barcodes[]=123&barcodes[]=456",
         content_type="application/json",
@@ -138,3 +138,16 @@ def test_get_plates_endpoint_successful(app, client, samples, mocked_responses, 
             {"plate_barcode": "456", "plate_map": False, "number_of_positives": None},
         ]
     }
+
+
+def test_get_plates_endpoint_fail(app, client, samples, mocked_responses):
+    with patch(
+        "lighthouse.blueprints.plates.has_sample_data",
+        side_effect=Exception("Boom!"),
+    ):
+        response = client.get(
+            "/plates?barcodes[]=123&barcodes[]=456",
+            content_type="application/json",
+        )
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert response.json == {"errors": ["Failed to lookup plates: Exception"]}

--- a/tests/blueprints/test_plates.py
+++ b/tests/blueprints/test_plates.py
@@ -124,3 +124,17 @@ def test_post_plates_mlwh_update_failure(app, client, samples, mocked_responses)
                     "Failed to update MLWH with COG UK ids. The samples should have been successfully inserted into Sequencescape."
                 ]
             }
+
+
+def test_get_plates_endpoint_successful(app, client, samples, mocked_responses, mlwh_lh_samples):
+    response = client.get(
+        "/plates?barcodes[]=123&barcodes[]=456",
+        content_type="application/json",
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == {
+        "plates": [
+            {"plate_barcode": "123", "plate_map": True, "number_of_positives": 3},
+            {"plate_barcode": "456", "plate_map": False, "number_of_positives": None},
+        ]
+    }

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -23,6 +23,7 @@ from lighthouse.helpers.plates import (
     get_centre_prefix,
     get_samples,
     get_positive_samples,
+    count_positive_samples,
     update_mlwh_with_cog_uk_ids,
     UnmatchedSampleError,
 )
@@ -149,6 +150,16 @@ def test_get_positive_samples(app, samples):
 def test_get_positive_samples_different_plates(app, samples_different_plates):
     with app.app_context():
         assert len(get_positive_samples("123")) == 1
+
+
+def test_count_positive_samples(app, samples):
+    with app.app_context():
+        assert count_positive_samples("123") == 3
+
+
+def test_count_positive_samples_different_plates(app, samples_different_plates):
+    with app.app_context():
+        assert count_positive_samples("123") == 1
 
 
 def test_update_mlwh_with_cog_uk_ids(


### PR DESCRIPTION
Add box-buster support

Closes #147

Add plates endpoint
Note: This may need revisiting, as currently hits mongo once per plate.
Performance wise this is about 4s per box (depending of course on box
size).

We can likely improve this by performing an aggregate query. This will
be much easier once the positive calls are persisted in mongo
(Which is all happening about the same time as this) this will also
avoid any issues cause if the positive criteria should change.

Sanger version of original PR due to CI issues:
https://github.com/sanger/lighthouse/pull/170