### PR TITLE
Gpl 742 messaging

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ flask-apscheduler = "~=1.11"
 pymysql = "~=0.10"
 sqlalchemy = "~=1.3"
 pyodbc = "~=4.0"
+pika = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f04977b18fb13ca8421cb2090c23bfe820f455a3c6ed76d35f3f6d97dceae8f0"
+            "sha256": "c675e7b072291cb62f2bed3a355ee9a2b30e8122224b35d3d6a1d52f1e9e195f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,42 +18,46 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:027be45c4b37e21be81d07ae5242361d73eebad1562c033f80032f955f34df82",
-                "sha256:06efdb01ab71ec20786b592d510d1d354fbe0b2e4449ee47067b9ca65d45a006",
-                "sha256:0989ff15834a4503056d103077ec3652f9ea5699835e1ceaee46b91cf59830bf",
-                "sha256:11e087c316e933f1f52f3d4a09ce13f15ad966fc43df47f44ca4e8067b6a2e0d",
-                "sha256:184ead67248274f0e20b0cd6bb5f25209b2fad56e5373101cc0137c32c825c87",
-                "sha256:1c36b7ef47cfbc150314c2204cd73613d96d6d0982d41c7679b7cdcf43c0e979",
-                "sha256:2aea79734ac5ceeac1ec22b4af4efb4efd6a5ca3d73d77ec74ed782cf318f238",
-                "sha256:2e886611b100c8c93b753b457e645c5e4b8008ec443434d2a480e5a2bb3e6514",
-                "sha256:476b1f8216e59a3c2ffb71b8d7e1da60304da19f6000d422bacc371abb0fc43d",
-                "sha256:48104c883099c0e614c5c38f98c1d174a2c68f52f58b2a6e5a07b59df78262ab",
-                "sha256:4afd8002d9238e5e93acf1a8baa38b3ddf1f7f0ebef174374131ff0c6c2d7973",
-                "sha256:547b196a7177511da4f475fc81d0bb88a51a8d535c7444bbf2338b6dc82cb996",
-                "sha256:67f8564c534d75c1d613186939cee45a124d7d37e7aece83b17d18af665b0d7a",
-                "sha256:6e0d1231a626d07b23f6fe904caa44efb249da4222d8a16ab039fb2348722292",
-                "sha256:7e26712871ebaf55497a60f55483dc5e74326d1fb0bfceab86ebaeaa3a266733",
-                "sha256:7f1aeb72f14b9254296cdefa029c00d3c4550a26e1059084f2ee10d22086c2d0",
-                "sha256:8319a55de469d5af3517dfe1f6a77f248f6668c5a552396635ef900f058882ef",
-                "sha256:835bd35e14e4f36414e47c195e6645449a0a1c3fd5eeae4b7f22cb4c5e4f503a",
-                "sha256:89c1aa729953b5ac6ca3c82dcbd83e7cdecfa5cf9792c78c154a642e6e29303d",
-                "sha256:8a8addd41320637c1445fea0bae1fd9fe4888acc2cd79217ee33e5d1c83cfe01",
-                "sha256:8fbeeb2296bb9fe16071a674eadade7391be785ae0049610e64b60ead6abcdd7",
-                "sha256:a1f1cc11c9856bfa7f1ca55002c39070bde2a97ce48ef631468e99e2ac8e3fe6",
-                "sha256:ad5c3559e3cd64f746df43fa498038c91aa14f5d7615941ea5b106e435f3b892",
-                "sha256:b822bf7b764283b5015e3c49b7bb93f37fc03545f4abe26383771c6b1c813436",
-                "sha256:b84cef790cb93cec82a468b7d2447bf16e3056d2237b652e80f57d653b61da88",
-                "sha256:be9fa3fe94fc95e9bf84e84117a577c892906dd3cb0a95a7ae21e12a84777567",
-                "sha256:c53f1d2bd48f5f407b534732f5b3c6b800a58e70b53808637848d8a9ee127fe7",
-                "sha256:c588a0f824dc7158be9eec1ff465d1c868ad69a4dc518cd098cc11e4f7da09d9",
-                "sha256:c6da1af59841e6d43255d386a2c4bfb59c0a3b262bdb24325cc969d211be6070",
-                "sha256:c9a415f4f2764ab6c7d63ee6b86f02a46b4df9bc11b0de7ffef206908b7bf0b4",
-                "sha256:cdbb65c361ff790c424365a83a496fc8dd1983689a5fb7c6852a9a3ff1710c61",
-                "sha256:f04dcbf6af1868048a9b4754b1684c669252aa2419aa67266efbcaaead42ced7",
-                "sha256:f8c583c31c6e790dc003d9d574e3ed2c5b337947722965096c4d684e4f183570"
+                "sha256:0b795072bb1bf87b8620120a6373a3c61bfcb8da7e5c2377f4bb23ff4f0b62c9",
+                "sha256:0d438c8ca703b1b714e82ed5b7a4412c82577040dadff479c08405e2a715564f",
+                "sha256:16a3cb5df5c56f696234ea9e65e227d1ebe9c18aa774d36ff42f532139066a5f",
+                "sha256:1edfd82a98c5161497bbb111b2b70c0813102ad7e0aa81cbeb34e64c93863005",
+                "sha256:2406dc1dda01c7f6060ab586e4601f18affb7a6b965c50a8c90ff07569cf782a",
+                "sha256:2858b2504c8697beb9357be01dc47ef86438cc1cb36ecb6991796d19475faa3e",
+                "sha256:2a7b7640167ab536c3cb90cfc3977c7094f1c5890d7eeede8b273c175c3910fd",
+                "sha256:3228b7a51e3ed533f5472f54f70fd0b0a64c48dc1649a0f0e809bec312934d7a",
+                "sha256:328b552513d4f95b0a2eea4c8573e112866107227661834652a8984766aa7656",
+                "sha256:39f4b0a6ae22a1c567cb0630c30dd082481f95c13ca528dc501a7766b9c718c0",
+                "sha256:3b0036c978cbcc4a4512278e98e3e6d9e6b834dc973206162eddf98b586ef1c6",
+                "sha256:3ea8c252d8df5e9166bcf3d9edced2af132f4ead8ac422eac723c5781063709a",
+                "sha256:41608c0acbe0899c852281978492f9ce2c6fbfaf60aff0cefc54a7c4516b822c",
+                "sha256:59d11674964b74a81b149d4ceaff2b674b3b0e4d0f10f0be1533e49c4a28408b",
+                "sha256:5e479df4b2d0f8f02133b7e4430098699450e1b2a826438af6bec9a400530957",
+                "sha256:684850fb1e3e55c9220aad007f8386d8e3e477c4ec9211ae54d968ecdca8c6f9",
+                "sha256:6ccc43d68b81c424e46192a778f97da94ee0630337c9bbe5b2ecc9b0c1c59001",
+                "sha256:6d42debaf55450643146fabe4b6817bb2a55b23698b0434107e892a43117285e",
+                "sha256:710376bf67d8ff4500a31d0c207b8941ff4fba5de6890a701d71680474fe2a60",
+                "sha256:756ae7efddd68d4ea7d89c636b703e14a0c686688d42f588b90778a3c2fc0564",
+                "sha256:77149002d9386fae303a4a162e6bce75cc2161347ad2ba06c2f0182561875d45",
+                "sha256:78e2f18a82b88cbc37d22365cf8d2b879a492faedb3f2975adb4ed8dfe994d3a",
+                "sha256:7d9b42127a6c0bdcc25c3dcf252bb3ddc70454fac593b1b6933ae091396deb13",
+                "sha256:8389d6044ee4e2037dca83e3f6994738550f6ee8cfb746762283fad9b932868f",
+                "sha256:9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4",
+                "sha256:c1e0920909d916d3375c7a1fdb0b1c78e46170e8bb42792312b6eb6676b2f87f",
+                "sha256:c68fdf21c6f3573ae19c7ee65f9ff185649a060c9a06535e9c3a0ee0bbac9235",
+                "sha256:c733ef3bdcfe52a1a75564389bad4064352274036e7e234730526d155f04d914",
+                "sha256:c9c58b0b84055d8bc27b7df5a9d141df4ee6ff59821f922dd73155861282f6a3",
+                "sha256:d03abec50df423b026a5aa09656bd9d37f1e6a49271f123f31f9b8aed5dc3ea3",
+                "sha256:d2cfac21e31e841d60dc28c0ec7d4ec47a35c608cb8906435d47ef83ffb22150",
+                "sha256:dcc119db14757b0c7bce64042158307b9b1c76471e655751a61b57f5a0e4d78e",
+                "sha256:df3a7b258cc230a65245167a202dd07320a5af05f3d41da1488ba0fa05bc9347",
+                "sha256:df48a623c58180874d7407b4d9ec06a19b84ed47f60a3884345b1a5099c1818b",
+                "sha256:e1b95972a0ae3f248a899cdbac92ba2e01d731225f566569311043ce2226f5e7",
+                "sha256:f326b3c1bbfda5b9308252ee0dcb30b612ee92b0e105d4abec70335fab5b1245",
+                "sha256:f411cb22115cb15452d099fec0ee636b06cf81bfb40ed9c02d30c8dc2bc2e3d1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.7.2"
+            "version": "==3.7.3"
         },
         "apscheduler": {
             "hashes": [
@@ -334,6 +338,14 @@
             ],
             "index": "pypi",
             "version": "==1.1.4"
+        },
+        "pika": {
+            "hashes": [
+                "sha256:4e1a1a6585a41b2341992ec32aadb7a919d649eb82904fd8e4a4e0871c8cf3af",
+                "sha256:9fa76ba4b65034b878b2b8de90ff8660a59d925b087c5bb88f8fdbb4b64a1dbf"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "pymongo": {
             "hashes": [

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -32,7 +32,8 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
         errors, message = construct_event_message(event_type, request.args)
         if len(errors) > 0:
             logger.error(
-                "Failed publishing plate event message: error(s) constructing event message"
+                "Failed publishing plate event message: error(s) constructing event message: "
+                f"{errors}"
             )
             return {"errors": errors}, HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -5,6 +5,13 @@ from typing import Any, Dict, Tuple
 from flask import Blueprint, request
 from flask_cors import CORS  # type: ignore
 
+from lighthouse.messages.broker import Broker  # type: ignore
+from lighthouse.messages.message import Message  # type: ignore
+
+from lighthouse.helpers.plate_events import (
+    construct_event_message,
+)
+
 logger = logging.getLogger(__name__)
 
 bp = Blueprint("plate-events", __name__)
@@ -14,25 +21,26 @@ CORS(bp)
 @bp.route("/plate-events/create", methods=["GET"])
 def create_plate_event() -> Tuple[Dict[str, Any], int]:
     try:
-        barcode = request.args.get("barcode", "")
+        # attempt to extract the event type
         event_type = request.args.get("event_type", "")
-        if len(barcode) == 0 or len(event_type) == 0:
-            return {
-                "errors": ["GET request needs 'barcode' and 'event_type' in url"]
-            }, HTTPStatus.BAD_REQUEST
-        else:
-            logger.info(
-                f"Attempting to create a '{event_type}' event for plate with barcode '{barcode}'"
-            )
+        if len(event_type) == 0:
+            return {"errors": ["'event_type' is a required parameter"]}, HTTPStatus.BAD_REQUEST
+
+        logger.info(f"Attempting to create an '{event_type}' event message")
+        errors, message = construct_event_message(event_type, request.args)
+        if len(errors) > 0:
+            return {"errors": errors}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+        logger.info(f"Attempting to publish the '{event_type}' event message")
+        broker = Broker()
+        broker.connect()
+        broker.publish(message)
+        broker.close_connection()
+        logger.info(f"Successfully published the '{event_type}' event message")
     except Exception as e:
         logger.exception(e)
         return {
-            "errors": [
-                "An error occurred attempting to determine 'barcode' and 'event_type' from "
-                "url parameters"
-            ]
+            "errors": ["An unexpected error occurred attempting to publish a plate event message"]
         }, HTTPStatus.INTERNAL_SERVER_ERROR
-
-    # TODO - implement
 
     return ({}, HTTPStatus.OK)

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -6,8 +6,6 @@ from flask import Blueprint, request
 from flask_cors import CORS  # type: ignore
 
 from lighthouse.messages.broker import Broker  # type: ignore
-from lighthouse.messages.message import Message  # type: ignore
-
 from lighthouse.helpers.plate_events import (
     construct_event_message,
 )
@@ -50,4 +48,4 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
             "errors": ["An unexpected error occurred attempting to publish a plate event message"]
         }, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    return ({}, HTTPStatus.OK)
+    return ({"errors": []}, HTTPStatus.OK)

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -21,23 +21,24 @@ CORS(bp)
 @bp.route("/plate-events/create", methods=["GET"])
 def create_plate_event() -> Tuple[Dict[str, Any], int]:
     try:
-        # attempt to extract the event type
         event_type = request.args.get("event_type", "")
+        logger.info(f"Attempting to publish an '{event_type}' plate event message")
         if len(event_type) == 0:
             return {"errors": ["'event_type' is a required parameter"]}, HTTPStatus.BAD_REQUEST
 
-        logger.info(f"Attempting to create an '{event_type}' event message")
+        logger.debug("Attempting to construct the plate event message")
         errors, message = construct_event_message(event_type, request.args)
         if len(errors) > 0:
             return {"errors": errors}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-        logger.info(f"Attempting to publish the '{event_type}' event message")
+        logger.debug("Attempting to publish the constructed plate event message")
         broker = Broker()
         broker.connect()
         broker.publish(message)
         broker.close_connection()
-        logger.info(f"Successfully published the '{event_type}' event message")
+        logger.info(f"Successfully published a '{event_type}' plate event message")
     except Exception as e:
+        logger.error("An error occurred attempting to publish a plate event message")
         logger.exception(e)
         return {
             "errors": ["An unexpected error occurred attempting to publish a plate event message"]

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -8,6 +8,7 @@ from flask_cors import CORS  # type: ignore
 from lighthouse.messages.broker import Broker  # type: ignore
 from lighthouse.helpers.plate_events import (
     construct_event_message,
+    get_routing_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,10 +36,13 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
             )
             return {"errors": errors}, HTTPStatus.INTERNAL_SERVER_ERROR
 
+        # By this stage we know the event type is valid as we have been able to construct a message
+        routing_key = get_routing_key(event_type)
+
         logger.debug("Attempting to publish the constructed plate event message")
         broker = Broker()
         broker.connect()
-        broker.publish(message)
+        broker.publish(message, routing_key)
         broker.close_connection()
         logger.info(f"Successfully published a '{event_type}' plate event message")
     except Exception as e:

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -24,11 +24,17 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
         event_type = request.args.get("event_type", "")
         logger.info(f"Attempting to publish an '{event_type}' plate event message")
         if len(event_type) == 0:
+            logger.error(
+                "Failed publishing plate event message: missing required 'event_type' parameter"
+            )
             return {"errors": ["'event_type' is a required parameter"]}, HTTPStatus.BAD_REQUEST
 
         logger.debug("Attempting to construct the plate event message")
         errors, message = construct_event_message(event_type, request.args)
         if len(errors) > 0:
+            logger.error(
+                "Failed publishing plate event message: error(s) constructing event message"
+            )
             return {"errors": errors}, HTTPStatus.INTERNAL_SERVER_ERROR
 
         logger.debug("Attempting to publish the constructed plate event message")
@@ -38,7 +44,7 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
         broker.close_connection()
         logger.info(f"Successfully published a '{event_type}' plate event message")
     except Exception as e:
-        logger.error("An error occurred attempting to publish a plate event message")
+        logger.error("Failed publishing plate event message: an unexpected error occurred")
         logger.exception(e)
         return {
             "errors": ["An unexpected error occurred attempting to publish a plate event message"]

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -28,7 +28,7 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
             )
             return {"errors": ["'event_type' is a required parameter"]}, HTTPStatus.BAD_REQUEST
 
-        logger.debug("Attempting to construct the plate event message")
+        logger.info("Attempting to construct the plate event message")
         errors, message = construct_event_message(event_type, request.args)
         if len(errors) > 0:
             logger.error(
@@ -39,7 +39,7 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
         # By this stage we know the event type is valid as we have been able to construct a message
         routing_key = get_routing_key(event_type)
 
-        logger.debug("Attempting to publish the constructed plate event message")
+        logger.info("Attempting to publish the constructed plate event message")
         broker = Broker()
         broker.connect()
         broker.publish(message, routing_key)

--- a/lighthouse/blueprints/plate_events.py
+++ b/lighthouse/blueprints/plate_events.py
@@ -43,14 +43,17 @@ def create_plate_event() -> Tuple[Dict[str, Any], int]:
         logger.info("Attempting to publish the constructed plate event message")
         broker = Broker()
         broker.connect()
-        broker.publish(message, routing_key)
-        broker.close_connection()
-        logger.info(f"Successfully published a '{event_type}' plate event message")
+        try:
+            broker.publish(message, routing_key)
+            broker.close_connection()
+            logger.info(f"Successfully published a '{event_type}' plate event message")
+            return ({"errors": []}, HTTPStatus.OK)
+        except Exception:
+            broker.close_connection()
+            raise
     except Exception as e:
         logger.error("Failed publishing plate event message: an unexpected error occurred")
         logger.exception(e)
         return {
             "errors": ["An unexpected error occurred attempting to publish a plate event message"]
         }, HTTPStatus.INTERNAL_SERVER_ERROR
-
-    return ({"errors": []}, HTTPStatus.OK)

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -126,6 +126,7 @@ RMQ_PORT = 5672
 RMQ_USERNAME = "guest"
 RMQ_PASSWORD = "guest"
 RMQ_VHOST = "/"
+RMQ_DECLARE_EXCHANGE = True
 RMQ_EXCHANGE = "lighthouse.examples"
 RMQ_EXCHANGE_TYPE = "topic"
 RMQ_ROUTING_KEY = ""

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -131,3 +131,10 @@ RMQ_EXCHANGE = "lighthouse.examples"
 RMQ_EXCHANGE_TYPE = "topic"
 RMQ_ROUTING_KEY = "staging.event.#"
 RMQ_LIMS_ID = "LH_LOCAL"
+
+BECKMAN_ROBOTS = {
+    "BKRB0001": {"name": "Robot 1", "uuid": "082effc3-f769-4e83-9073-dc7aacd5f71b"},
+    "BKRB0002": {"name": "Robot 2", "uuid": "4fe4ca2b-09a7-40d6-a0ce-0e5dd5f30c47"},
+    "BKRB0003": {"name": "Robot 3", "uuid": "90d8bc7a-2f6e-4a5f-8bea-1e8d27a1ac89"},
+    "BKRB0004": {"name": "Robot 4", "uuid": "675002fe-f364-47e4-b71f-4fe1bb7b5091"},
+}

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -120,3 +120,12 @@ LOGGING: Dict[str, Any] = {
 
 DART_RESULT_VIEW = "CherrypickingInfo"
 BARACODA_RETRY_ATTEMPTS = 3
+
+RMQ_HOST = "localhost"
+RMQ_PORT = 5672
+RMQ_USERNAME = "guest"
+RMQ_PASSWORD = "guest"
+RMQ_VHOST = "/"
+RMQ_EXCHANGE = "lighthouse.examples"
+RMQ_EXCHANGE_TYPE = "topic"
+RMQ_ROUTING_KEY = ""

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -129,4 +129,5 @@ RMQ_VHOST = "/"
 RMQ_DECLARE_EXCHANGE = True
 RMQ_EXCHANGE = "lighthouse.examples"
 RMQ_EXCHANGE_TYPE = "topic"
-RMQ_ROUTING_KEY = ""
+RMQ_ROUTING_KEY = "staging.event.#"
+RMQ_LIMS_ID = "LH_LOCAL"

--- a/lighthouse/config/test.py
+++ b/lighthouse/config/test.py
@@ -48,3 +48,14 @@ EVENT_WH_EVENTS_TABLE = "events"
 EVENT_WH_EVENT_TYPES_TABLE = "event_types"
 EVENT_WH_SUBJECT_TYPES_TABLE = "subject_types"
 EVENT_WH_ROLE_TYPES_TABLE = "role_types"
+
+RMQ_HOST = "localhost"
+RMQ_PORT = 5672
+RMQ_USERNAME = "guest"
+RMQ_PASSWORD = "guest"
+RMQ_VHOST = "/"
+RMQ_DECLARE_EXCHANGE = True
+RMQ_EXCHANGE = "lighthouse.test.examples"
+RMQ_EXCHANGE_TYPE = "topic"
+RMQ_ROUTING_KEY = "test.event.#"
+RMQ_LIMS_ID = "LH_TEST"

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -17,6 +17,9 @@ FIELD_DATE_TESTED = "Date Tested"
 FIELD_CH1_CQ = "CH1-Cq"
 FIELD_CH2_CQ = "CH2-Cq"
 FIELD_CH3_CQ = "CH3-Cq"
+FIELD_LH_SOURCE_PLATE_UUID = "lh_source_plate_uuid"
+FIELD_LH_SAMPLE_UUID = "lh_sample_uuid"
+FIELD_BARCODE = "barcode"
 
 # DART specific column names:
 FIELD_DART_DESTINATION_BARCODE = os.environ.get("FIELD_DART_DESTINATION_BARCODE", "Labware BarCode")

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -87,6 +87,6 @@ POSITIVE_SAMPLES_MONGODB_FILTER = {
 }
 
 PLATE_EVENT_SOURCE_COMPLETED = "lh_beckman_cp_source_completed"
-PLATE_EVENT_SOURCE_NOT_RECOGNISED = "lh_beckam_cp_source_plate_unrecognised"
+PLATE_EVENT_SOURCE_NOT_RECOGNISED = "lh_beckman_cp_source_plate_unrecognised"
 PLATE_EVENT_SOURCE_NO_MAP_DATA = "lh_beckman_cp_source_no_plate_map_data"
 PLATE_EVENT_SOURCE_ALL_NEGATIVES = "lh_beckman_cp_source_all_negatives"

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -85,3 +85,8 @@ POSITIVE_SAMPLES_MONGODB_FILTER = {
         },
     ],
 }
+
+PLATE_EVENT_SOURCE_COMPLETED = "lh_beckman_cp_source_completed"
+PLATE_EVENT_SOURCE_NOT_RECOGNISED = "lh_beckam_cp_source_plate_unrecognised"
+PLATE_EVENT_SOURCE_NO_MAP_DATA = "lh_beckman_cp_source_no_plate_map_data"
+PLATE_EVENT_SOURCE_ALL_NEGATIVES = "lh_beckman_cp_source_all_negatives"

--- a/lighthouse/helpers/mongo_db.py
+++ b/lighthouse/helpers/mongo_db.py
@@ -1,0 +1,51 @@
+from flask import current_app as app
+import logging
+from typing import List, Dict, Any, Optional
+from lighthouse.constants import FIELD_LH_SOURCE_PLATE_UUID, FIELD_BARCODE
+
+logger = logging.getLogger(__name__)
+
+
+def get_source_plate_uuid(barcode: str) -> Optional[str]:
+    """Attempt to get a uuid for a source plate barcode.
+
+    Arguments:
+        barcode {str} -- The source plate barcode.
+
+    Returns:
+        {str} -- The source plate uuid; otherwise None if it cannot be determined.
+    """
+    try:
+        source_plates_collection = app.data.driver.db.source_plates
+        source_plate = source_plates_collection.find_one({FIELD_BARCODE: barcode})
+        if source_plate is None:
+            return None
+
+        return source_plate.get(FIELD_LH_SOURCE_PLATE_UUID, None)
+    except Exception as e:
+        logger.error(
+            f"An error occurred attempting to determine the uuid of source plate '{barcode}'"
+        )
+        logger.exception(e)
+        return None
+
+
+def get_samples(source_plate_uuid: str) -> Optional[List[Dict[str, Any]]]:
+    """Attempt to get a source plate's samples.
+
+    Arguments:
+        source_plate_uuid {str} -- The source plate uuid for which to get samples.
+
+    Returns:
+        {List[Dict[str, str]]} -- A list of all samples on the source plate;
+        otherwise None if they cannot be determined
+    """
+    try:
+        samples_collection = app.data.driver.db.samples
+        return list(samples_collection.find({FIELD_LH_SOURCE_PLATE_UUID: source_plate_uuid}))
+    except Exception as e:
+        logger.error(
+            f"An error occurred attempting to fetch samples on source plate '{source_plate_uuid}'"
+        )
+        logger.exception(e)
+        return None

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -129,46 +129,7 @@ def construct_source_plate_no_map_data_message(
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
     """
-    try:
-        barcode = params.get("barcode", "")
-        user_id = params.get("user_id", "")
-        robot_serial_number = params.get("robot", "")
-        if len(barcode) == 0 or len(user_id) == 0 or len(robot_serial_number) == 0:
-            return [
-                "'barcode', 'user_id' and 'robot' are required to construct a "
-                f"{PLATE_EVENT_SOURCE_NO_MAP_DATA} event message"
-            ], None
-
-        robot_uuid = __get_robot_uuid(robot_serial_number)
-        if robot_uuid is None:
-            return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
-
-        source_plate_uuid = __get_source_plate_uuid(barcode)
-        if source_plate_uuid is None:
-            return [f"Unable to determine a uuid for source plate '{barcode}'"], None
-
-        message_content = {
-            "event": {
-                "uuid": str(uuid4()),
-                "event_type": PLATE_EVENT_SOURCE_NO_MAP_DATA,
-                "occured_at": __get_current_datetime(),
-                "user_identifier": user_id,
-                "subjects": [
-                    __get_robot_message_subject(robot_serial_number, robot_uuid),
-                    __get_source_plate_message_subject(barcode, source_plate_uuid),
-                ],
-                "metadata": {},
-            },
-            "lims": app.config["RMQ_LIMS_ID"],
-        }
-        return [], Message(message_content)
-    except Exception as e:
-        logger.error(f"Failed to construct a {PLATE_EVENT_SOURCE_NO_MAP_DATA} message")
-        logger.exception(e)
-        return [
-            "An unexpected error occurred attempting to construct the "
-            f"{PLATE_EVENT_SOURCE_NO_MAP_DATA} event message"
-        ], None
+    return __construct_default_source_plate_on_robot_message(PLATE_EVENT_SOURCE_NO_MAP_DATA, params)
 
 
 def construct_source_plate_all_negatives_message(
@@ -184,7 +145,9 @@ def construct_source_plate_all_negatives_message(
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
     """
-    return ["Not implemented"], None
+    return __construct_default_source_plate_on_robot_message(
+        PLATE_EVENT_SOURCE_ALL_NEGATIVES, params
+    )
 
 
 # Private methods
@@ -221,6 +184,61 @@ def __get_source_plate_uuid(barcode: str) -> Optional[str]:
         {str} -- The source plate uuid; otherwise None if it cannot be determined.
     """
     return str(uuid4())  # TODO - get the source plate uuid from Mongo
+
+
+def __construct_default_source_plate_on_robot_message(
+    event_type: str, params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Constructs a default message representing a source plate event on a robot, without samples;
+    otherwise returns appropriate errors.
+
+    Arguments:
+        event_type {str} -- The type of event to create.
+        params {Dict[str, str]} -- All parameters of the plate event message request.
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    try:
+        barcode = params.get("barcode", "")
+        user_id = params.get("user_id", "")
+        robot_serial_number = params.get("robot", "")
+        if len(barcode) == 0 or len(user_id) == 0 or len(robot_serial_number) == 0:
+            return [
+                "'barcode', 'user_id' and 'robot' are required to construct a "
+                f"{event_type} event message"
+            ], None
+
+        robot_uuid = __get_robot_uuid(robot_serial_number)
+        if robot_uuid is None:
+            return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
+
+        source_plate_uuid = __get_source_plate_uuid(barcode)
+        if source_plate_uuid is None:
+            return [f"Unable to determine a uuid for source plate '{barcode}'"], None
+
+        message_content = {
+            "event": {
+                "uuid": str(uuid4()),
+                "event_type": event_type,
+                "occured_at": __get_current_datetime(),
+                "user_identifier": user_id,
+                "subjects": [
+                    __get_robot_message_subject(robot_serial_number, robot_uuid),
+                    __get_source_plate_message_subject(barcode, source_plate_uuid),
+                ],
+                "metadata": {},
+            },
+            "lims": app.config["RMQ_LIMS_ID"],
+        }
+        return [], Message(message_content)
+    except Exception as e:
+        logger.error(f"Failed to construct a {event_type} message")
+        logger.exception(e)
+        return [
+            f"An unexpected error occurred attempting to construct the {event_type} event message"
+        ], None
 
 
 def __get_robot_message_subject(serial_number: str, uuid: str) -> Dict[str, str]:

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -91,7 +91,7 @@ def construct_source_plate_not_recognised_message(
                 f"{PLATE_EVENT_SOURCE_NOT_RECOGNISED} event message"
             ], None
 
-        robot_uuid = get_robot_uuid(robot_serial_number)
+        robot_uuid = __get_robot_uuid(robot_serial_number)
         if robot_uuid is None:
             return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
 
@@ -99,7 +99,7 @@ def construct_source_plate_not_recognised_message(
             "event": {
                 "uuid": str(uuid4()),
                 "event_type": PLATE_EVENT_SOURCE_NOT_RECOGNISED,
-                "occured_at": get_current_datetime(),
+                "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
                 "subjects": [
                     {
@@ -146,11 +146,11 @@ def construct_source_plate_no_map_data_message(
                 f"{PLATE_EVENT_SOURCE_NO_MAP_DATA} event message"
             ], None
 
-        robot_uuid = get_robot_uuid(robot_serial_number)
+        robot_uuid = __get_robot_uuid(robot_serial_number)
         if robot_uuid is None:
             return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
 
-        source_plate_uuid = get_source_plate_uuid(barcode)
+        source_plate_uuid = __get_source_plate_uuid(barcode)
         if source_plate_uuid is None:
             return [f"Unable to determine a uuid for source plate '{barcode}'"], None
 
@@ -158,7 +158,7 @@ def construct_source_plate_no_map_data_message(
             "event": {
                 "uuid": str(uuid4()),
                 "event_type": PLATE_EVENT_SOURCE_NO_MAP_DATA,
-                "occured_at": get_current_datetime(),
+                "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
                 "subjects": [
                     {
@@ -204,7 +204,10 @@ def construct_source_plate_all_negatives_message(
     return ["Not implemented"], None
 
 
-def get_current_datetime() -> str:
+# Private methods
+
+
+def __get_current_datetime() -> str:
     """Returns the current datetime in a format compatible with messaging.
 
     Returns:
@@ -213,7 +216,7 @@ def get_current_datetime() -> str:
     return datetime.now().isoformat(timespec="seconds")
 
 
-def get_robot_uuid(serial_number: str) -> Optional[str]:
+def __get_robot_uuid(serial_number: str) -> Optional[str]:
     """Maps a robot serial number to a uuid.
 
     Arguments:
@@ -225,7 +228,7 @@ def get_robot_uuid(serial_number: str) -> Optional[str]:
     return str(uuid4())  # TODO - get robot uuid from config
 
 
-def get_source_plate_uuid(barcode: str) -> Optional[str]:
+def __get_source_plate_uuid(barcode: str) -> Optional[str]:
     """Attempt to get a uuid for a source plate barcode.
 
     Arguments:

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -95,7 +95,6 @@ def construct_source_plate_not_recognised_message(
         if robot_uuid is None:
             return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
 
-        robot_uuid = str(uuid4())  # TODO - get robot uuid from config
         message_content = {
             "event": {
                 "uuid": str(uuid4()),

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -10,6 +10,10 @@ from lighthouse.constants import (
     PLATE_EVENT_SOURCE_NO_MAP_DATA,
     PLATE_EVENT_SOURCE_ALL_NEGATIVES,
 )
+from lighthouse.helpers.mongo_db import (
+    get_source_plate_uuid,
+    get_samples,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -174,18 +178,6 @@ def __get_robot_uuid(serial_number: str) -> Optional[str]:
     return app.config["BECKMAN_ROBOTS"].get(serial_number, {}).get("uuid", None)
 
 
-def __get_source_plate_uuid(barcode: str) -> Optional[str]:
-    """Attempt to get a uuid for a source plate barcode.
-
-    Arguments:
-        barcode {str} -- The source plate barcode.
-
-    Returns:
-        {str} -- The source plate uuid; otherwise None if it cannot be determined.
-    """
-    return str(uuid4())  # TODO - get the source plate uuid from Mongo
-
-
 def __construct_default_source_plate_on_robot_message(
     event_type: str, params: Dict[str, str]
 ) -> Tuple[List[str], Optional[Message]]:
@@ -214,7 +206,7 @@ def __construct_default_source_plate_on_robot_message(
         if robot_uuid is None:
             return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
 
-        source_plate_uuid = __get_source_plate_uuid(barcode)
+        source_plate_uuid = get_source_plate_uuid(barcode)
         if source_plate_uuid is None:
             return [f"Unable to determine a uuid for source plate '{barcode}'"], None
 

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -30,6 +30,18 @@ def construct_event_message(
         return [f"Unrecognised event type '{event_type}'"], None
 
 
+def get_routing_key(event_type: str) -> str:
+    """Determines the routing key for a plate event message.
+
+    Arguments:
+        event_type {str} -- The event type for which to determine a routing key
+
+    Returns:
+        {str} -- The message routing key.
+    """
+    return app.config["RMQ_ROUTING_KEY"].replace("#", event_type)
+
+
 def construct_source_plate_completed_message(
     params: Dict[str, str]
 ) -> Tuple[List[str], Optional[Message]]:

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -1,5 +1,11 @@
 from typing import Optional, Dict, Tuple, List
 from lighthouse.messages.message import Message  # type: ignore
+from lighthouse.constants import (
+    PLATE_EVENT_SOURCE_COMPLETED,
+    PLATE_EVENT_SOURCE_NOT_RECOGNISED,
+    PLATE_EVENT_SOURCE_NO_MAP_DATA,
+    PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+)
 
 
 def construct_event_message(
@@ -12,19 +18,19 @@ def construct_event_message(
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
     """
-    if event_type == "lh_beckman_cp_source_completed":
-        return construct_source_plate_complete_message(params)
-    elif event_type == "lh_beckman_cp_source_plate_unrecognised":
+    if event_type == PLATE_EVENT_SOURCE_COMPLETED:
+        return construct_source_plate_completed_message(params)
+    elif event_type == PLATE_EVENT_SOURCE_NOT_RECOGNISED:
         return construct_source_plate_not_recognised_message(params)
-    elif event_type == "lh_beckman_cp_source_no_plate_map_data":
+    elif event_type == PLATE_EVENT_SOURCE_NO_MAP_DATA:
         return construct_source_plate_no_map_data_message(params)
-    elif event_type == "lh_beckman_cp_source_all_negatives":
+    elif event_type == PLATE_EVENT_SOURCE_ALL_NEGATIVES:
         return construct_source_plate_all_negatives_message(params)
     else:
         return [f"Unrecognised event type '{event_type}'"], None
 
 
-def construct_source_plate_complete_message(
+def construct_source_plate_completed_message(
     params: Dict[str, str]
 ) -> Tuple[List[str], Optional[Message]]:
     """Constructs a message representing a source plate complete event;

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -171,7 +171,7 @@ def __get_robot_uuid(serial_number: str) -> Optional[str]:
     Returns:
         {str} -- The robot uuid; otherwise None if it cannot be determined.
     """
-    return str(uuid4())  # TODO - get robot uuid from config
+    return app.config["BECKMAN_ROBOTS"].get(serial_number, {}).get("uuid", None)
 
 
 def __get_source_plate_uuid(barcode: str) -> Optional[str]:

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -105,7 +105,7 @@ def construct_source_plate_not_recognised_message(
                 "event_type": PLATE_EVENT_SOURCE_NOT_RECOGNISED,
                 "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
-                "subjects": [__get_robot_message_subject(robot_serial_number, robot_uuid)],
+                "subjects": [__construct_robot_message_subject(robot_serial_number, robot_uuid)],
                 "metadata": {},
             },
             "lims": app.config["RMQ_LIMS_ID"],
@@ -217,8 +217,8 @@ def __construct_default_source_plate_on_robot_message(
                 "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
                 "subjects": [
-                    __get_robot_message_subject(robot_serial_number, robot_uuid),
-                    __get_source_plate_message_subject(barcode, source_plate_uuid),
+                    __construct_robot_message_subject(robot_serial_number, robot_uuid),
+                    __construct_source_plate_message_subject(barcode, source_plate_uuid),
                 ],
                 "metadata": {},
             },
@@ -233,7 +233,7 @@ def __construct_default_source_plate_on_robot_message(
         ], None
 
 
-def __get_robot_message_subject(serial_number: str, uuid: str) -> Dict[str, str]:
+def __construct_robot_message_subject(serial_number: str, uuid: str) -> Dict[str, str]:
     """Generates a robot subject for a plate event message.
 
     Arguments:
@@ -251,7 +251,7 @@ def __get_robot_message_subject(serial_number: str, uuid: str) -> Dict[str, str]
     }
 
 
-def __get_source_plate_message_subject(barcode: str, uuid: str) -> Dict[str, str]:
+def __construct_source_plate_message_subject(barcode: str, uuid: str) -> Dict[str, str]:
     """Generates a source plate subject for a plate event message.
 
     Arguments:

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -12,7 +12,11 @@ def construct_event_message(
     event_type: str, params: Dict[str, str]
 ) -> Tuple[List[str], Optional[Message]]:
     """Delegates to the appropriate event construction method;
-    otherwise returns with errors for unknown event type
+    otherwise returns with errors for unknown event type.
+
+    Arguments:
+        event_type {str} -- The event type for which to construct a message.
+        params {Dict[str, str]} -- All parameters of the plate event message request.
 
     Returns:
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
@@ -48,6 +52,9 @@ def construct_source_plate_completed_message(
     """Constructs a message representing a source plate complete event;
     otherwise returns appropriate errors.
 
+    Arguments:
+        params {Dict[str, str]} -- All parameters of the plate event message request.
+
     Returns:
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
@@ -62,6 +69,9 @@ def construct_source_plate_not_recognised_message(
     """Constructs a message representing a source plate not recognised event;
     otherwise returns appropriate errors.
 
+    Arguments:
+        params {Dict[str, str]} -- All parameters of the plate event message request.
+
     Returns:
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
@@ -75,6 +85,9 @@ def construct_source_plate_no_map_data_message(
     """Constructs a message representing a source plate without plate map data event;
     otherwise returns appropriate errors.
 
+    Arguments:
+        params {Dict[str, str]} -- All parameters of the plate event message request.
+
     Returns:
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
@@ -87,6 +100,9 @@ def construct_source_plate_all_negatives_message(
 ) -> Tuple[List[str], Optional[Message]]:
     """Constructs a message representing a source plate without positives event;
     otherwise returns appropriate errors.
+
+    Arguments:
+        params {Dict[str, str]} -- All parameters of the plate event message request.
 
     Returns:
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -1,0 +1,77 @@
+from typing import Optional, Dict, Tuple, List
+from lighthouse.messages.message import Message  # type: ignore
+
+
+def construct_event_message(
+    event_type: str, params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Delegates to the appropriate event construction method;
+    otherwise returns with errors for unknown event type
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    if event_type == "lh_beckman_cp_source_completed":
+        return construct_source_plate_complete_message(params)
+    elif event_type == "lh_beckman_cp_source_plate_unrecognised":
+        return construct_source_plate_not_recognised_message(params)
+    elif event_type == "lh_beckman_cp_source_no_plate_map_data":
+        return construct_source_plate_no_map_data_message(params)
+    elif event_type == "lh_beckman_cp_source_all_negatives":
+        return construct_source_plate_all_negatives_message(params)
+    else:
+        return [f"Unrecognised event type '{event_type}'"], None
+
+
+def construct_source_plate_complete_message(
+    params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Constructs a message representing a source plate complete event;
+    otherwise returns appropriate errors.
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    # try get required params
+    return ["Not implemented"], None
+
+
+def construct_source_plate_not_recognised_message(
+    params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Constructs a message representing a source plate not recognised event;
+    otherwise returns appropriate errors.
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    return ["Not implemented"], None
+
+
+def construct_source_plate_no_map_data_message(
+    params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Constructs a message representing a source plate without plate map data event;
+    otherwise returns appropriate errors.
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    return ["Not implemented"], None
+
+
+def construct_source_plate_all_negatives_message(
+    params: Dict[str, str]
+) -> Tuple[List[str], Optional[Message]]:
+    """Constructs a message representing a source plate without positives event;
+    otherwise returns appropriate errors.
+
+    Returns:
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+        {Message} -- The constructed message; otherwise None if there are any errors.
+    """
+    return ["Not implemented"], None

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -117,7 +117,8 @@ def construct_source_plate_completed_message(
         logger.error(f"Failed to construct a {PLATE_EVENT_SOURCE_COMPLETED} message")
         logger.exception(e)
         return [
-            f"An unexpected error occurred attempting to construct the {PLATE_EVENT_SOURCE_COMPLETED} event message"
+            "An unexpected error occurred attempting to construct the "
+            f"{PLATE_EVENT_SOURCE_COMPLETED} event message"
         ], None
 
 
@@ -326,12 +327,14 @@ def __construct_sample_message_subject(sample: Dict[str, str]) -> Dict[str, str]
     Returns:
         {Dict[str, str]} -- The plate message sample subject.
     """
-    friendly_name = "__".join([
-        sample[FIELD_ROOT_SAMPLE_ID],
-        sample[FIELD_RNA_ID],
-        sample[FIELD_LAB_ID],
-        sample[FIELD_RESULT],
-    ])
+    friendly_name = "__".join(
+        [
+            sample[FIELD_ROOT_SAMPLE_ID],
+            sample[FIELD_RNA_ID],
+            sample[FIELD_LAB_ID],
+            sample[FIELD_RESULT],
+        ]
+    )
     return {
         "role_type": "sample",
         "subject_type": "sample",

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -101,14 +101,7 @@ def construct_source_plate_not_recognised_message(
                 "event_type": PLATE_EVENT_SOURCE_NOT_RECOGNISED,
                 "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
-                "subjects": [
-                    {
-                        "role_type": "robot",
-                        "subject_type": "robot",
-                        "friendly_name": robot_serial_number,
-                        "uuid": robot_uuid,
-                    }
-                ],
+                "subjects": [__get_robot_message_subject(robot_serial_number, robot_uuid)],
                 "metadata": {},
             },
             "lims": app.config["RMQ_LIMS_ID"],
@@ -161,18 +154,8 @@ def construct_source_plate_no_map_data_message(
                 "occured_at": __get_current_datetime(),
                 "user_identifier": user_id,
                 "subjects": [
-                    {
-                        "role_type": "robot",
-                        "subject_type": "robot",
-                        "friendly_name": robot_serial_number,
-                        "uuid": robot_uuid,
-                    },
-                    {
-                        "role_type": "cherrypicking_source_labware",
-                        "subject_type": "plate",
-                        "friendly_name": barcode,
-                        "uuid": source_plate_uuid,
-                    },
+                    __get_robot_message_subject(robot_serial_number, robot_uuid),
+                    __get_source_plate_message_subject(barcode, source_plate_uuid),
                 ],
                 "metadata": {},
             },
@@ -238,3 +221,39 @@ def __get_source_plate_uuid(barcode: str) -> Optional[str]:
         {str} -- The source plate uuid; otherwise None if it cannot be determined.
     """
     return str(uuid4())  # TODO - get the source plate uuid from Mongo
+
+
+def __get_robot_message_subject(serial_number: str, uuid: str) -> Dict[str, str]:
+    """Generates a robot subject for a plate event message.
+
+    Arguments:
+        serial_number {str} -- The robot serial number.
+        uuid {str} -- The robot uuid.
+
+    Returns:
+        {Dict[str, str]} -- The robot message subject.
+    """
+    return {
+        "role_type": "robot",
+        "subject_type": "robot",
+        "friendly_name": serial_number,
+        "uuid": uuid,
+    }
+
+
+def __get_source_plate_message_subject(barcode: str, uuid: str) -> Dict[str, str]:
+    """Generates a source plate subject for a plate event message.
+
+    Arguments:
+        barcode {str} -- The source plate barcode.
+        uuid {str} -- The robot uuid.
+
+    Returns:
+        {Dict[str, str]} -- The source plate message subject.
+    """
+    return {
+        "role_type": "cherrypicking_source_labware",
+        "subject_type": "plate",
+        "friendly_name": barcode,
+        "uuid": uuid,
+    }

--- a/lighthouse/helpers/plate_events.py
+++ b/lighthouse/helpers/plate_events.py
@@ -1,4 +1,8 @@
+import logging
 from typing import Optional, Dict, Tuple, List
+from uuid import uuid4
+from datetime import datetime
+from flask import current_app as app
 from lighthouse.messages.message import Message  # type: ignore
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
@@ -6,6 +10,8 @@ from lighthouse.constants import (
     PLATE_EVENT_SOURCE_NO_MAP_DATA,
     PLATE_EVENT_SOURCE_ALL_NEGATIVES,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def construct_event_message(
@@ -76,7 +82,46 @@ def construct_source_plate_not_recognised_message(
         {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
         {Message} -- The constructed message; otherwise None if there are any errors.
     """
-    return ["Not implemented"], None
+    try:
+        user_id = params.get("user_id", "")
+        robot_serial_number = params.get("robot", "")
+        if len(user_id) == 0 or len(robot_serial_number) == 0:
+            return [
+                "'user_id' and 'robot' are required to construct a "
+                f"{PLATE_EVENT_SOURCE_NOT_RECOGNISED} event message"
+            ], None
+
+        robot_uuid = get_robot_uuid(robot_serial_number)
+        if robot_uuid is None:
+            return [f"Unable to determine a uuid for robot '{robot_serial_number}'"], None
+
+        robot_uuid = str(uuid4())  # TODO - get robot uuid from config
+        message_content = {
+            "event": {
+                "uuid": str(uuid4()),
+                "event_type": PLATE_EVENT_SOURCE_NOT_RECOGNISED,
+                "occured_at": get_current_datetime(),
+                "user_identifier": user_id,
+                "subjects": [
+                    {
+                        "role_type": "robot",
+                        "subject_type": "robot",
+                        "friendly_name": robot_serial_number,
+                        "uuid": robot_uuid,
+                    }
+                ],
+                "metadata": {},
+            },
+            "lims": app.config["RMQ_LIMS_ID"],
+        }
+        return [], Message(message_content)
+    except Exception as e:
+        logger.error(f"Failed to construct a {PLATE_EVENT_SOURCE_NOT_RECOGNISED} message")
+        logger.exception(e)
+        return [
+            "An unexpected error occurred attempting to construct the "
+            f"{PLATE_EVENT_SOURCE_NOT_RECOGNISED} event message"
+        ], None
 
 
 def construct_source_plate_no_map_data_message(
@@ -109,3 +154,26 @@ def construct_source_plate_all_negatives_message(
         {Message} -- The constructed message; otherwise None if there are any errors.
     """
     return ["Not implemented"], None
+
+
+def get_current_datetime() -> str:
+    """Returns the current datetime in a format compatible with messaging.
+
+    Returns:
+        {str} -- The current datetime.
+    """
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def get_robot_uuid(serial_number: str) -> str:
+    """Maps a robot serial number to a uuid.
+
+    Arguments:
+        params {str} -- The robot serial number.
+
+    Returns:
+        {str} -- The robot uuid.
+    """
+    return str(uuid4())  # TODO - get robot uuid from config
+
+

--- a/lighthouse/messages/broker.py
+++ b/lighthouse/messages/broker.py
@@ -1,0 +1,49 @@
+import pika
+import logging
+from lighthouse.messages.message import Message
+from flask import current_app as app
+
+logger = logging.getLogger(__name__)
+
+
+class Broker:
+    """Controls the connection, exchange and publishing to RabbitMQ."""
+
+    def connect(self) -> None:
+        self.__create_connection()
+        self.__open_channel()
+        self.__declare_exchange()
+
+    def publish(self, message: Message) -> None:
+        if message is not None:
+            logger.debug("Publishing message")
+            self.channel.basic_publish(
+                exchange=app.config["RMQ_EXCHANGE"],
+                routing_key=app.config["RMQ_ROUTING_KEY"],
+                body=message.payload(),
+            )
+
+    def close_connection(self) -> None:
+        logger.debug("Closing connection")
+        self.channel = None
+        self.connection.close()
+
+    def __create_connection(self) -> None:
+        host = app.config["RMQ_HOST"]
+        logger.debug(f"Creating messaging connection to '{host}'")
+        credentials = pika.PlainCredentials(app.config["RMQ_USERNAME"], app.config["RMQ_PASSWORD"])
+        parameters = pika.ConnectionParameters(
+            host, app.config["RMQ_PORT"], app.config["RMQ_VHOST"], credentials
+        )
+        self.connection = pika.BlockingConnection(parameters)
+
+    def __open_channel(self) -> None:
+        logger.debug("Opening channel")
+        self.channel = self.connection.channel()
+
+    def __declare_exchange(self) -> None:
+        exchange_name = app.config["RMQ_EXCHANGE"]
+        logger.debug(f"Declaring exchange '{exchange_name}'")
+        self.channel.exchange_declare(
+            exchange_name, exchange_type=app.config["RMQ_EXCHANGE_TYPE"], passive=True
+        )

--- a/lighthouse/messages/broker.py
+++ b/lighthouse/messages/broker.py
@@ -25,7 +25,6 @@ class Broker:
 
     def close_connection(self) -> None:
         logger.debug("Closing connection")
-        self.channel = None
         self.connection.close()
 
     def __create_connection(self) -> None:

--- a/lighthouse/messages/broker.py
+++ b/lighthouse/messages/broker.py
@@ -15,12 +15,12 @@ class Broker:
         if app.config["RMQ_DECLARE_EXCHANGE"]:
             self.__declare_exchange()
 
-    def publish(self, message: Message) -> None:
-        if message is not None:
+    def publish(self, message: Message, routing_key: str) -> None:
+        if message is not None and routing_key is not None:
             logger.debug("Publishing message")
             self.channel.basic_publish(
                 exchange=app.config["RMQ_EXCHANGE"],
-                routing_key=app.config["RMQ_ROUTING_KEY"],
+                routing_key=routing_key,
                 body=message.payload(),
             )
 

--- a/lighthouse/messages/broker.py
+++ b/lighthouse/messages/broker.py
@@ -44,6 +44,4 @@ class Broker:
     def __declare_exchange(self) -> None:
         exchange_name = app.config["RMQ_EXCHANGE"]
         logger.debug(f"Declaring exchange '{exchange_name}'")
-        self.channel.exchange_declare(
-            exchange_name, exchange_type=app.config["RMQ_EXCHANGE_TYPE"]
-        )
+        self.channel.exchange_declare(exchange_name, exchange_type=app.config["RMQ_EXCHANGE_TYPE"])

--- a/lighthouse/messages/broker.py
+++ b/lighthouse/messages/broker.py
@@ -12,7 +12,8 @@ class Broker:
     def connect(self) -> None:
         self.__create_connection()
         self.__open_channel()
-        self.__declare_exchange()
+        if app.config["RMQ_DECLARE_EXCHANGE"]:
+            self.__declare_exchange()
 
     def publish(self, message: Message) -> None:
         if message is not None:
@@ -44,5 +45,5 @@ class Broker:
         exchange_name = app.config["RMQ_EXCHANGE"]
         logger.debug(f"Declaring exchange '{exchange_name}'")
         self.channel.exchange_declare(
-            exchange_name, exchange_type=app.config["RMQ_EXCHANGE_TYPE"], passive=True
+            exchange_name, exchange_type=app.config["RMQ_EXCHANGE_TYPE"]
         )

--- a/lighthouse/messages/message.py
+++ b/lighthouse/messages/message.py
@@ -1,0 +1,17 @@
+import json
+from typing import Any
+
+
+class Message:
+    """Creates a message with the correct payload structure to send to the warehouse."""
+
+    def __init__(self, message: Any = None):
+        self.message = message
+
+    def payload(self) -> str:
+        """Generates the JSON payload of the message.
+
+        Returns:
+            {str} -- The message JSON payload.
+        """
+        return json.dumps(self.message)

--- a/lighthouse/messages/message.py
+++ b/lighthouse/messages/message.py
@@ -5,7 +5,7 @@ from typing import Any
 class Message:
     """Creates a message with the correct payload structure to send to the warehouse."""
 
-    def __init__(self, message: Any = None):
+    def __init__(self, message=None):
         self.message = message
 
     def payload(self) -> str:

--- a/lighthouse/messages/message.py
+++ b/lighthouse/messages/message.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 
 class Message:

--- a/tests/blueprints/test_plate_events.py
+++ b/tests/blueprints/test_plate_events.py
@@ -1,22 +1,78 @@
 from http import HTTPStatus
-
-
-def test_get_create_plate_event_endpoint_bad_request_no_barcode(client):
-    response = client.get("/plate-events/create?event_type=test_type)")
-
-    assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert len(response.json["errors"]) == 1
+from unittest.mock import patch
+from lighthouse.messages.message import Message
 
 
 def test_get_create_plate_event_endpoint_bad_request_no_event_type(client):
-    response = client.get("/plate-events/create?barcode=test_barcode)")
+    response = client.get("/plate-events/create")
 
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert len(response.json["errors"]) == 1
 
 
-def test_get_create_plate_event_endpoint_ok(client):
-    response = client.get("/plate-events/create?barcode=test_barcode&event_type=test_type)")
+def test_get_create_plate_event_endpoint_bad_request_empty_event_type(client):
+    response = client.get("/plate-events/create?event_type=")
 
-    assert response.status_code == HTTPStatus.OK
-    assert not response.json
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert len(response.json["errors"]) == 1
+
+
+def test_get_create_plate_event_endpoint_internal_error_failed_constructing_message(client):
+    with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
+        test_error_message = "test error"
+        mock_construct.return_value = [test_error_message], None
+
+        response = client.get("/plate-events/create?event_type=test_event_type")
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert len(response.json["errors"]) == 1
+        assert response.json["errors"][0] == test_error_message
+
+
+def test_get_create_plate_event_endpoint_internal_error_failed_broker_initialise(client):
+    with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
+        with patch("lighthouse.blueprints.plate_events.Broker", side_effect=Exception("Boom!")):
+            mock_construct.return_value = [], Message("test message content")
+
+            response = client.get("/plate-events/create?event_type=test_event_type")
+
+            assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+            assert len(response.json["errors"]) == 1
+
+
+def test_get_create_plate_event_endpoint_internal_error_failed_broker_connect(client):
+    with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
+        with patch(
+            "lighthouse.blueprints.plate_events.Broker.connect", side_effect=Exception("Boom!")
+        ):
+            mock_construct.return_value = [], Message("test message content")
+
+            response = client.get("/plate-events/create?event_type=test_event_type")
+
+            assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+            assert len(response.json["errors"]) == 1
+
+
+def test_get_create_plate_event_endpoint_internal_error_failed_broker_publish(client):
+    with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
+        with patch(
+            "lighthouse.blueprints.plate_events.Broker.publish", side_effect=Exception("Boom!")
+        ):
+            mock_construct.return_value = [], Message("test message content")
+
+            response = client.get("/plate-events/create?event_type=test_event_type")
+
+            assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+            assert len(response.json["errors"]) == 1
+
+
+def test_get_create_plate_event_endpoint_success(client):
+    with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
+        with patch("lighthouse.blueprints.plate_events.Broker"):
+            test_message = Message("test message content")
+            mock_construct.return_value = [], test_message
+
+            response = client.get("/plate-events/create?event_type=test_event_type")
+
+            assert response.status_code == HTTPStatus.OK
+            assert len(response.json["errors"]) == 0

--- a/tests/blueprints/test_plate_events.py
+++ b/tests/blueprints/test_plate_events.py
@@ -55,24 +55,25 @@ def test_get_create_plate_event_endpoint_internal_error_failed_broker_connect(cl
 
 def test_get_create_plate_event_endpoint_internal_error_failed_broker_publish(client):
     with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
-        with patch(
-            "lighthouse.blueprints.plate_events.Broker.publish", side_effect=Exception("Boom!")
-        ):
+        with patch("lighthouse.blueprints.plate_events.Broker") as mock_broker:
+            mock_broker().publish.side_effect = Exception("Boom!")
             mock_construct.return_value = [], Message("test message content")
 
             response = client.get("/plate-events/create?event_type=test_event_type")
 
+            mock_broker().close_connection.assert_called()
             assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
             assert len(response.json["errors"]) == 1
 
 
 def test_get_create_plate_event_endpoint_success(client):
     with patch("lighthouse.blueprints.plate_events.construct_event_message") as mock_construct:
-        with patch("lighthouse.blueprints.plate_events.Broker"):
+        with patch("lighthouse.blueprints.plate_events.Broker") as mock_broker:
             test_message = Message("test message content")
             mock_construct.return_value = [], test_message
 
             response = client.get("/plate-events/create?event_type=test_event_type")
 
+            mock_broker().close_connection.assert_called()
             assert response.status_code == HTTPStatus.OK
             assert len(response.json["errors"]) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,10 @@ from .data.fixture_data import (
     SAMPLES_DIFFERENT_PLATES,
     DART_MONGO_MERGED_SAMPLES,
     SAMPLES_WITH_LAB_ID,
+    SAMPLES_WITH_UUIDS,
     EVENT_WH_DATA,
     MLWH_SAMPLE_STOCK_RESOURCE,
+    SOURCE_PLATES,
 )
 from lighthouse.helpers.mysql_db import create_mysql_connection_engine, get_table
 from lighthouse.helpers.dart_db import create_dart_connection, load_sql_server_script
@@ -375,3 +377,31 @@ def event_wh_sql_engine(app):
     return create_mysql_connection_engine(
         app.config["WAREHOUSES_RW_CONN_STRING"], app.config["EVENTS_WH_DB"]
     )
+
+
+@pytest.fixture
+def source_plates(app):
+    with app.app_context():
+        source_plates_collection = app.data.driver.db.source_plates
+        _ = source_plates_collection.insert_many(SOURCE_PLATES)
+
+    #  yield a copy of that the test change it however it wants
+    yield copy.deepcopy(SOURCE_PLATES)
+
+    # clear up after the fixture is used
+    with app.app_context():
+        source_plates_collection.delete_many({})
+
+
+@pytest.fixture
+def samples_with_uuids(app):
+    with app.app_context():
+        samples_collection = app.data.driver.db.samples
+        _ = samples_collection.insert_many(SAMPLES_WITH_UUIDS)
+
+    #  yield a copy of that the test change it however it wants
+    yield copy.deepcopy(SAMPLES_WITH_UUIDS)
+
+    # clear up after the fixture is used
+    with app.app_context():
+        samples_collection.delete_many({})

--- a/tests/data/fixture_data.py
+++ b/tests/data/fixture_data.py
@@ -1,6 +1,7 @@
 from copy import copy
 from datetime import datetime
 from typing import Any, Dict, List
+from uuid import uuid4
 
 from lighthouse.constants import (
     FIELD_CH1_CQ,
@@ -23,6 +24,9 @@ from lighthouse.constants import (
     FIELD_RNA_ID,
     FIELD_ROOT_SAMPLE_ID,
     FIELD_SOURCE,
+    FIELD_LH_SOURCE_PLATE_UUID,
+    FIELD_LH_SAMPLE_UUID,
+    FIELD_BARCODE,
     MLWH_LH_SAMPLE_RESULT,
     MLWH_LH_SAMPLE_RNA_ID,
     MLWH_LH_SAMPLE_ROOT_SAMPLE_ID,
@@ -548,3 +552,30 @@ EVENT_WH_DATA: Dict[str, Any] = {
     "subject_types": [{"id": 1, "key": "sample", "description": "stuff"}],
     "role_types": [{"id": 1, "key": "sample", "description": "stuff"}],
 }
+
+SOURCE_PLATES = [
+    {
+        FIELD_LH_SOURCE_PLATE_UUID: str(uuid4()),
+        FIELD_BARCODE: "123",
+        FIELD_LAB_ID: "LAB 1",
+    },
+    {
+        FIELD_LH_SOURCE_PLATE_UUID: str(uuid4()),
+        FIELD_BARCODE: "456",
+        FIELD_LAB_ID: "LAB 2",
+    },
+]
+
+
+def inject_uuids(sample):
+    sample_copy = copy(sample)
+    sample_copy[FIELD_LH_SOURCE_PLATE_UUID] = next(
+        x[FIELD_LH_SOURCE_PLATE_UUID]
+        for x in SOURCE_PLATES
+        if x[FIELD_BARCODE] == sample_copy[FIELD_PLATE_BARCODE]
+    )
+    sample_copy[FIELD_LH_SAMPLE_UUID] = str(uuid4())
+    return sample_copy
+
+
+SAMPLES_WITH_UUIDS = [inject_uuids(sample) for sample in SAMPLES_WITH_LAB_ID]

--- a/tests/helpers/test_mongo_db.py
+++ b/tests/helpers/test_mongo_db.py
@@ -1,0 +1,50 @@
+from unittest.mock import patch
+from lighthouse.helpers.mongo_db import (
+    get_source_plate_uuid,
+    get_samples,
+)
+from lighthouse.constants import (
+    FIELD_BARCODE,
+    FIELD_LH_SOURCE_PLATE_UUID,
+)
+
+
+def test_get_source_plate_uuid_returns_uuid(app, source_plates):
+    with app.app_context():
+        result = get_source_plate_uuid(source_plates[0][FIELD_BARCODE])
+        assert result == source_plates[0][FIELD_LH_SOURCE_PLATE_UUID]
+
+
+def test_get_source_plate_uuid_returns_none_no_plate_with_barcode(app, source_plates):
+    with app.app_context():
+        result = get_source_plate_uuid("barcode does not exist")
+        assert result is None
+
+
+def test_get_source_plate_uuid_returns_none_failure_fetching_plates(app, source_plates):
+    with app.app_context():
+        with patch("flask.current_app.data.driver.db.source_plates") as source_plates_collection:
+            source_plates_collection.find_one.side_effect = Exception("Boom!")
+            result = get_source_plate_uuid(source_plates[0][FIELD_BARCODE])
+            assert result is None
+
+
+def test_get_samples_returns_matching_samples(app, samples_with_uuids):
+    with app.app_context():
+        source_plate_uuid = samples_with_uuids[0][FIELD_LH_SOURCE_PLATE_UUID]
+        result = get_samples(source_plate_uuid)
+        assert result == samples_with_uuids
+
+
+def test_get_samples_returns_empty_list_no_matching_samples(app, samples_with_uuids):
+    with app.app_context():
+        result = get_samples("source plate uuid does not exist")
+        assert result == []
+
+
+def test_get_samples_returns_none_failure_fetching_samples(app, samples_with_uuids):
+    with app.app_context():
+        with patch("flask.current_app.data.driver.db.samples") as samples_collection:
+            samples_collection.find.side_effect = Exception("Boom!")
+            result = get_samples(samples_with_uuids[0][FIELD_LH_SOURCE_PLATE_UUID])
+            assert result is None

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -6,12 +6,18 @@ from lighthouse.helpers.plate_events import (
     construct_source_plate_not_recognised_message,
     construct_source_plate_no_map_data_message,
     construct_source_plate_all_negatives_message,
+    construct_source_plate_completed_message,
 )
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
     PLATE_EVENT_SOURCE_NOT_RECOGNISED,
     PLATE_EVENT_SOURCE_NO_MAP_DATA,
     PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+    FIELD_ROOT_SAMPLE_ID,
+    FIELD_RNA_ID,
+    FIELD_LAB_ID,
+    FIELD_RESULT,
+    FIELD_LH_SAMPLE_UUID,
 )
 
 
@@ -316,7 +322,7 @@ def test_construct_source_plate_no_map_data_message_creates_expected_message(app
                     "friendly_name": test_robot_serial_number,
                     "uuid": test_robot_uuid,
                 } in subjects
-                assert {
+                assert {  # source plate subject
                     "role_type": "cherrypicking_source_labware",
                     "subject_type": "plate",
                     "friendly_name": test_barcode,
@@ -459,9 +465,220 @@ def test_construct_source_plate_all_negatives_message_creates_expected_message(a
                     "friendly_name": test_robot_serial_number,
                     "uuid": test_robot_uuid,
                 } in subjects
-                assert {
+                assert {  # source plate subject
                     "role_type": "cherrypicking_source_labware",
                     "subject_type": "plate",
                     "friendly_name": test_barcode,
                     "uuid": test_source_plate_uuid,
                 } in subjects
+
+
+# ---------- construct_source_plate_completed_message tests ----------
+
+
+def test_construct_source_plate_completed_message_errors_without_barcode():
+    test_params = {"user_id": "test user", "robot": "12345"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "", "user_id": "test user", "robot": "12345"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_without_user_id():
+    test_params = {"barcode": "ABC123", "robot": "12345"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "ABC123", "user_id": "", "robot": "12345"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_without_robot():
+    test_params = {"barcode": "ABC123", "user_id": "test user"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "ABC123", "user_id": "test user", "robot": ""}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_with_failure_getting_robot_uuid():
+    # don't provide an app config to query
+    test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+    errors, message = construct_source_plate_completed_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_without_robot_uuid(app):
+    with app.app_context():
+        test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_completed_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_with_failure_getting_plate_uuid(app):
+    with app.app_context():
+        test_robot_serial_number, _ = any_robot_info(app)
+        with patch(
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
+            side_effect=Exception("Boom!"),
+        ):
+            test_params = {
+                "barcode": "ABC123",
+                "user_id": "test_user",
+                "robot": test_robot_serial_number,
+            }
+            errors, message = construct_source_plate_completed_message(test_params)
+
+            assert len(errors) == 1
+            assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_without_source_plate_uuid(app):
+    with app.app_context():
+        test_robot_serial_number, _ = any_robot_info(app)
+        with patch("lighthouse.helpers.plate_events.get_source_plate_uuid", return_value=None):
+            test_params = {
+                "barcode": "ABC123",
+                "user_id": "test_user",
+                "robot": test_robot_serial_number,
+            }
+            errors, message = construct_source_plate_completed_message(test_params)
+
+            assert len(errors) == 1
+            assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_with_failure_getting_samples(app):
+    with app.app_context():
+        test_robot_serial_number, _ = any_robot_info(app)
+        test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
+        with patch(
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
+            return_value=test_source_plate_uuid,
+        ):
+            with patch("lighthouse.helpers.plate_events.get_samples", side_effect=Exception("Boom!")):
+                test_params = {
+                    "barcode": "ABC123",
+                    "user_id": "test_user",
+                    "robot": test_robot_serial_number,
+                }
+                errors, message = construct_source_plate_completed_message(test_params)
+
+                assert len(errors) == 1
+                assert message is None
+
+
+def test_construct_source_plate_completed_message_errors_without_source_plate_uuid(app):
+    with app.app_context():
+        test_robot_serial_number, _ = any_robot_info(app)
+        test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
+        with patch(
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
+            return_value=test_source_plate_uuid,
+        ):
+            with patch("lighthouse.helpers.plate_events.get_samples", return_value=None):
+                test_params = {
+                    "barcode": "ABC123",
+                    "user_id": "test_user",
+                    "robot": test_robot_serial_number,
+                }
+                errors, message = construct_source_plate_completed_message(test_params)
+
+                assert len(errors) == 1
+                assert message is None
+
+
+def test_construct_source_plate_completed_message_creates_expected_message(app):
+    with app.app_context():
+        test_robot_serial_number, test_robot_uuid = any_robot_info(app)
+        test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
+        with patch(
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
+            return_value=test_source_plate_uuid,
+        ):
+            test_samples = [
+                {
+                    FIELD_ROOT_SAMPLE_ID: "MCM001",
+                    FIELD_RNA_ID: "rna_1",
+                    FIELD_LAB_ID: "Lab 1",
+                    FIELD_RESULT: "Positive",
+                    FIELD_LH_SAMPLE_UUID: "17be6834-06e7-4ce1-8413-9d8667cb9022",
+                    "friendly_name": "MCM001__rna_1__Lab 1__Positive",
+                },
+                {
+                    FIELD_ROOT_SAMPLE_ID: "MCM002",
+                    FIELD_RNA_ID: "rna_2",
+                    FIELD_LAB_ID: "Lab 1",
+                    FIELD_RESULT: "Negative",
+                    FIELD_LH_SAMPLE_UUID: "57c4e79d-04f4-4eeb-a2b9-316312ac3a3d",
+                    "friendly_name": "MCM002__rna_2__Lab 1__Negative",
+                }
+            ]
+            with patch("lighthouse.helpers.plate_events.get_samples", return_value=test_samples):
+                with patch("lighthouse.helpers.plate_events.Message") as mock_message:
+                    test_barcode = "ABC123"
+                    test_user_id = "test_user"
+                    test_params = {
+                        "barcode": test_barcode,
+                        "user_id": test_user_id,
+                        "robot": test_robot_serial_number,
+                    }
+                    errors, _ = construct_source_plate_completed_message(test_params)
+
+                    assert len(errors) == 0
+
+                    args, _ = mock_message.call_args
+                    message_content = args[0]
+
+                    assert message_content["lims"] == app.config["RMQ_LIMS_ID"]
+
+                    event = message_content["event"]
+                    assert event["uuid"] is not None
+                    assert event["event_type"] == PLATE_EVENT_SOURCE_COMPLETED
+                    assert event["occured_at"] is not None
+                    assert event["user_identifier"] == test_user_id
+
+                    subjects = event["subjects"]
+                    assert len(subjects) == 4
+                    assert {  # robot subject
+                        "role_type": "robot",
+                        "subject_type": "robot",
+                        "friendly_name": test_robot_serial_number,
+                        "uuid": test_robot_uuid,
+                    } in subjects
+                    assert {  # source plate subject
+                        "role_type": "cherrypicking_source_labware",
+                        "subject_type": "plate",
+                        "friendly_name": test_barcode,
+                        "uuid": test_source_plate_uuid,
+                    } in subjects
+
+                    # sample subjects
+                    for sample in test_samples:
+                        assert {
+                            "role_type": "sample",
+                            "subject_type": "sample",
+                            "friendly_name": sample["friendly_name"],
+                            "uuid": sample[FIELD_LH_SAMPLE_UUID],
+                        } in subjects

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -122,7 +122,7 @@ def test_construct_source_plate_not_recognised_message_errors_without_robot():
 
 
 def test_construct_source_plate_not_recognised_message_errors_with_failure_getting_robot_uuid():
-    with patch("lighthouse.helpers.plate_events.get_robot_uuid", side_effect=Exception("Boom!")):
+    with patch("lighthouse.helpers.plate_events.__get_robot_uuid", side_effect=Exception("Boom!")):
         test_params = {"user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_not_recognised_message(test_params)
 
@@ -131,7 +131,7 @@ def test_construct_source_plate_not_recognised_message_errors_with_failure_getti
 
 
 def test_construct_source_plate_not_recognised_message_errors_without_robot_uuid():
-    with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=None):
+    with patch("lighthouse.helpers.plate_events.__get_robot_uuid", return_value=None):
         test_params = {"user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_not_recognised_message(test_params)
 
@@ -142,7 +142,9 @@ def test_construct_source_plate_not_recognised_message_errors_without_robot_uuid
 def test_construct_source_plate_not_recognised_message_creates_expected_message(app):
     with app.app_context():
         test_robot_uuid = "adb83afb-d59a-47f2-8d2d-7f71703ca256"
-        with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=test_robot_uuid):
+        with patch(
+            "lighthouse.helpers.plate_events.__get_robot_uuid", return_value=test_robot_uuid
+        ):
             with patch("lighthouse.helpers.plate_events.Message") as mock_message:
                 test_user_id = "test_user"
                 test_robot_serial_number = "12345"
@@ -218,7 +220,7 @@ def test_construct_source_plate_no_map_data_message_errors_without_user_id():
 
 
 def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_robot_uuid():
-    with patch("lighthouse.helpers.plate_events.get_robot_uuid", side_effect=Exception("Boom!")):
+    with patch("lighthouse.helpers.plate_events.__get_robot_uuid", side_effect=Exception("Boom!")):
         test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_no_map_data_message(test_params)
 
@@ -227,7 +229,7 @@ def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_
 
 
 def test_construct_source_plate_no_map_data_message_errors_without_robot_uuid():
-    with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=None):
+    with patch("lighthouse.helpers.plate_events.__get_robot_uuid", return_value=None):
         test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_no_map_data_message(test_params)
 
@@ -237,7 +239,7 @@ def test_construct_source_plate_no_map_data_message_errors_without_robot_uuid():
 
 def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_source_plate_uuid():
     with patch(
-        "lighthouse.helpers.plate_events.get_source_plate_uuid", side_effect=Exception("Boom!")
+        "lighthouse.helpers.plate_events.__get_source_plate_uuid", side_effect=Exception("Boom!")
     ):
         test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_no_map_data_message(test_params)
@@ -247,7 +249,7 @@ def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_
 
 
 def test_construct_source_plate_no_map_data_message_errors_without_source_plate_uuid():
-    with patch("lighthouse.helpers.plate_events.get_source_plate_uuid", return_value=None):
+    with patch("lighthouse.helpers.plate_events.__get_source_plate_uuid", return_value=None):
         test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
         errors, message = construct_source_plate_no_map_data_message(test_params)
 
@@ -258,10 +260,12 @@ def test_construct_source_plate_no_map_data_message_errors_without_source_plate_
 def test_construct_source_plate_no_map_data_message_creates_expected_message(app):
     with app.app_context():
         test_robot_uuid = "adb83afb-d59a-47f2-8d2d-7f71703ca256"
-        with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=test_robot_uuid):
+        with patch(
+            "lighthouse.helpers.plate_events.__get_robot_uuid", return_value=test_robot_uuid
+        ):
             test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
             with patch(
-                "lighthouse.helpers.plate_events.get_source_plate_uuid",
+                "lighthouse.helpers.plate_events.__get_source_plate_uuid",
                 return_value=test_source_plate_uuid,
             ):
                 with patch("lighthouse.helpers.plate_events.Message") as mock_message:

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+from lighthouse.messages.message import Message
+from lighthouse.helpers.plate_events import (
+    construct_event_message,
+)
+from lighthouse.constants import (
+    PLATE_EVENT_SOURCE_COMPLETED,
+    PLATE_EVENT_SOURCE_NOT_RECOGNISED,
+    PLATE_EVENT_SOURCE_NO_MAP_DATA,
+    PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+)
+
+
+def test_construct_event_message_unrecognised_event():
+    errors, message = construct_event_message("not a real event", {})
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_event_message_source_complete():
+    with patch(
+        "lighthouse.helpers.plate_events.construct_source_plate_completed_message"
+    ) as mock_construct_source_completed_message:
+        test_return_value = ([], Message("test message"))
+        mock_construct_source_completed_message.return_value = test_return_value
+
+        test_params = {"test_key": "test_value"}
+        result = construct_event_message(PLATE_EVENT_SOURCE_COMPLETED, test_params)
+
+        mock_construct_source_completed_message.assert_called_with(test_params)
+        assert result == test_return_value
+
+
+def test_construct_event_message_source_not_recognised():
+    with patch(
+        "lighthouse.helpers.plate_events.construct_source_plate_not_recognised_message"
+    ) as mock_construct_source_not_recognised_message:
+        test_return_value = ([], Message("test message"))
+        mock_construct_source_not_recognised_message.return_value = test_return_value
+
+        test_params = {"test_key": "test_value"}
+        result = construct_event_message(PLATE_EVENT_SOURCE_NOT_RECOGNISED, test_params)
+
+        mock_construct_source_not_recognised_message.assert_called_with(test_params)
+        assert result == test_return_value
+
+
+def test_construct_event_message_source_no_map_data():
+    with patch(
+        "lighthouse.helpers.plate_events.construct_source_plate_no_map_data_message"
+    ) as mock_construct_source_no_map_data_message:
+        test_return_value = ([], Message("test message"))
+        mock_construct_source_no_map_data_message.return_value = test_return_value
+
+        test_params = {"test_key": "test_value"}
+        result = construct_event_message(PLATE_EVENT_SOURCE_NO_MAP_DATA, test_params)
+
+        mock_construct_source_no_map_data_message.assert_called_with(test_params)
+        assert result == test_return_value
+
+
+def test_construct_event_message_source_all_negatives():
+    with patch(
+        "lighthouse.helpers.plate_events.construct_source_plate_all_negatives_message"
+    ) as mock_construct_source_all_negatives_message:
+        test_return_value = ([], Message("test message"))
+        mock_construct_source_all_negatives_message.return_value = test_return_value
+
+        test_params = {"test_key": "test_value"}
+        result = construct_event_message(PLATE_EVENT_SOURCE_ALL_NEGATIVES, test_params)
+
+        mock_construct_source_all_negatives_message.assert_called_with(test_params)
+        assert result == test_return_value

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -248,7 +248,7 @@ def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_
     with app.app_context():
         test_robot_serial_number, _ = any_robot_info(app)
         with patch(
-            "lighthouse.helpers.plate_events.__get_source_plate_uuid",
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
             side_effect=Exception("Boom!"),
         ):
             test_params = {
@@ -265,7 +265,7 @@ def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_
 def test_construct_source_plate_no_map_data_message_errors_without_source_plate_uuid(app):
     with app.app_context():
         test_robot_serial_number, _ = any_robot_info(app)
-        with patch("lighthouse.helpers.plate_events.__get_source_plate_uuid", return_value=None):
+        with patch("lighthouse.helpers.plate_events.get_source_plate_uuid", return_value=None):
             test_params = {
                 "barcode": "ABC123",
                 "user_id": "test_user",
@@ -282,7 +282,7 @@ def test_construct_source_plate_no_map_data_message_creates_expected_message(app
         test_robot_serial_number, test_robot_uuid = any_robot_info(app)
         test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
         with patch(
-            "lighthouse.helpers.plate_events.__get_source_plate_uuid",
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
             return_value=test_source_plate_uuid,
         ):
             with patch("lighthouse.helpers.plate_events.Message") as mock_message:
@@ -391,7 +391,7 @@ def test_construct_source_plate_all_negatives_message_errors_with_failure_gettin
     with app.app_context():
         test_robot_serial_number, _ = any_robot_info(app)
         with patch(
-            "lighthouse.helpers.plate_events.__get_source_plate_uuid",
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
             side_effect=Exception("Boom!"),
         ):
             test_params = {
@@ -408,7 +408,7 @@ def test_construct_source_plate_all_negatives_message_errors_with_failure_gettin
 def test_construct_source_plate_all_negatives_message_errors_without_source_plate_uuid(app):
     with app.app_context():
         test_robot_serial_number, _ = any_robot_info(app)
-        with patch("lighthouse.helpers.plate_events.__get_source_plate_uuid", return_value=None):
+        with patch("lighthouse.helpers.plate_events.get_source_plate_uuid", return_value=None):
             test_params = {
                 "barcode": "ABC123",
                 "user_id": "test_user",
@@ -425,7 +425,7 @@ def test_construct_source_plate_all_negatives_message_creates_expected_message(a
         test_robot_serial_number, test_robot_uuid = any_robot_info(app)
         test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
         with patch(
-            "lighthouse.helpers.plate_events.__get_source_plate_uuid",
+            "lighthouse.helpers.plate_events.get_source_plate_uuid",
             return_value=test_source_plate_uuid,
         ):
             with patch("lighthouse.helpers.plate_events.Message") as mock_message:

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from lighthouse.messages.message import Message
 from lighthouse.helpers.plate_events import (
     construct_event_message,
+    get_routing_key,
 )
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
@@ -72,3 +73,11 @@ def test_construct_event_message_source_all_negatives():
 
         mock_construct_source_all_negatives_message.assert_called_with(test_params)
         assert result == test_return_value
+
+
+def test_get_routing_key(app):
+    with app.app_context():
+        test_event_type = "test_event_type"
+        result = get_routing_key(test_event_type)
+
+        assert result == f"test.event.{test_event_type}"

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -577,7 +577,9 @@ def test_construct_source_plate_completed_message_errors_with_failure_getting_sa
             "lighthouse.helpers.plate_events.get_source_plate_uuid",
             return_value=test_source_plate_uuid,
         ):
-            with patch("lighthouse.helpers.plate_events.get_samples", side_effect=Exception("Boom!")):
+            with patch(
+                "lighthouse.helpers.plate_events.get_samples", side_effect=Exception("Boom!")
+            ):
                 test_params = {
                     "barcode": "ABC123",
                     "user_id": "test_user",
@@ -589,7 +591,7 @@ def test_construct_source_plate_completed_message_errors_with_failure_getting_sa
                 assert message is None
 
 
-def test_construct_source_plate_completed_message_errors_without_source_plate_uuid(app):
+def test_construct_source_plate_completed_message_errors_without_samples(app):
     with app.app_context():
         test_robot_serial_number, _ = any_robot_info(app)
         test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
@@ -633,7 +635,7 @@ def test_construct_source_plate_completed_message_creates_expected_message(app):
                     FIELD_RESULT: "Negative",
                     FIELD_LH_SAMPLE_UUID: "57c4e79d-04f4-4eeb-a2b9-316312ac3a3d",
                     "friendly_name": "MCM002__rna_2__Lab 1__Negative",
-                }
+                },
             ]
             with patch("lighthouse.helpers.plate_events.get_samples", return_value=test_samples):
                 with patch("lighthouse.helpers.plate_events.Message") as mock_message:

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -3,6 +3,7 @@ from lighthouse.messages.message import Message
 from lighthouse.helpers.plate_events import (
     construct_event_message,
     get_routing_key,
+    construct_source_plate_not_recognised_message,
 )
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
@@ -10,6 +11,8 @@ from lighthouse.constants import (
     PLATE_EVENT_SOURCE_NO_MAP_DATA,
     PLATE_EVENT_SOURCE_ALL_NEGATIVES,
 )
+
+# ---------- construct_event_messages tests ----------
 
 
 def test_construct_event_message_unrecognised_event():
@@ -75,9 +78,90 @@ def test_construct_event_message_source_all_negatives():
         assert result == test_return_value
 
 
+# ---------- get_routing_key tests ----------
+
+
 def test_get_routing_key(app):
     with app.app_context():
         test_event_type = "test_event_type"
         result = get_routing_key(test_event_type)
 
         assert result == f"test.event.{test_event_type}"
+
+
+# ---------- construct_source_plate_not_recognised_message tests ----------
+
+
+def test_construct_source_plate_not_recognised_message_errors_without_user_id():
+    test_params = {"robot": "12345"}
+    errors, message = construct_source_plate_not_recognised_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"robot": "12345", "user_id": ""}
+    errors, message = construct_source_plate_not_recognised_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_not_recognised_message_errors_without_robot():
+    test_params = {"user_id": "test_user"}
+    errors, message = construct_source_plate_not_recognised_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"user_id": "test_user", "robot": ""}
+    errors, message = construct_source_plate_not_recognised_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_not_recognised_message_errors_with_failure_getting_robot_uuid():
+    with patch("lighthouse.helpers.plate_events.get_robot_uuid", side_effect=Exception("Boom!")):
+        test_params = {"user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_not_recognised_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_not_recognised_message_errors_without_robot_uuid():
+    with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=None):
+        test_params = {"user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_not_recognised_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_not_recognised_message_returns_expected_message(app):
+    with app.app_context():
+        test_robot_uuid = "adb83afb-d59a-47f2-8d2d-7f71703ca256"
+        with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=test_robot_uuid):
+            with patch("lighthouse.helpers.plate_events.Message") as mock_message:
+                test_user_id = "test_user"
+                test_robot_serial_number = "12345"
+                test_params = {"user_id": test_user_id, "robot": test_robot_serial_number}
+                errors, _ = construct_source_plate_not_recognised_message(test_params)
+
+                assert len(errors) == 0
+
+                args, _ = mock_message.call_args
+                message_content = args[0]
+                assert message_content["lims"] == app.config["RMQ_LIMS_ID"]
+                event = message_content["event"]
+                assert event["uuid"] is not None
+                assert event["event_type"] == PLATE_EVENT_SOURCE_NOT_RECOGNISED
+                assert event["occured_at"] is not None
+                assert event["user_identifier"] == test_user_id
+                subjects = event["subjects"]
+                assert len(subjects) == 1
+                robot_subject = subjects[0]
+                assert robot_subject["role_type"] == "robot"
+                assert robot_subject["subject_type"] == "robot"
+                assert robot_subject["friendly_name"] == test_robot_serial_number
+                assert robot_subject["uuid"] == test_robot_uuid

--- a/tests/helpers/test_plate_event_helpers.py
+++ b/tests/helpers/test_plate_event_helpers.py
@@ -4,6 +4,7 @@ from lighthouse.helpers.plate_events import (
     construct_event_message,
     get_routing_key,
     construct_source_plate_not_recognised_message,
+    construct_source_plate_no_map_data_message,
 )
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
@@ -138,7 +139,7 @@ def test_construct_source_plate_not_recognised_message_errors_without_robot_uuid
         assert message is None
 
 
-def test_construct_source_plate_not_recognised_message_returns_expected_message(app):
+def test_construct_source_plate_not_recognised_message_creates_expected_message(app):
     with app.app_context():
         test_robot_uuid = "adb83afb-d59a-47f2-8d2d-7f71703ca256"
         with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=test_robot_uuid):
@@ -152,16 +153,152 @@ def test_construct_source_plate_not_recognised_message_returns_expected_message(
 
                 args, _ = mock_message.call_args
                 message_content = args[0]
+
                 assert message_content["lims"] == app.config["RMQ_LIMS_ID"]
+
                 event = message_content["event"]
                 assert event["uuid"] is not None
                 assert event["event_type"] == PLATE_EVENT_SOURCE_NOT_RECOGNISED
                 assert event["occured_at"] is not None
                 assert event["user_identifier"] == test_user_id
+
                 subjects = event["subjects"]
                 assert len(subjects) == 1
-                robot_subject = subjects[0]
-                assert robot_subject["role_type"] == "robot"
-                assert robot_subject["subject_type"] == "robot"
-                assert robot_subject["friendly_name"] == test_robot_serial_number
-                assert robot_subject["uuid"] == test_robot_uuid
+                assert {  # robot subject
+                    "role_type": "robot",
+                    "subject_type": "robot",
+                    "friendly_name": test_robot_serial_number,
+                    "uuid": test_robot_uuid,
+                } in subjects
+
+
+# ---------- construct_source_plate_no_map_data_message tests ----------
+
+
+def test_construct_source_plate_no_map_data_message_errors_without_barcode():
+    test_params = {"user_id": "test user", "robot": "12345"}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "", "user_id": "test user", "robot": "12345"}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_without_user_id():
+    test_params = {"barcode": "ABC123", "robot": "12345"}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "ABC123", "user_id": "", "robot": "12345"}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_without_user_id():
+    test_params = {"barcode": "ABC123", "user_id": "test user"}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+    test_params = {"barcode": "ABC123", "user_id": "test user", "robot": ""}
+    errors, message = construct_source_plate_no_map_data_message(test_params)
+
+    assert len(errors) == 1
+    assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_robot_uuid():
+    with patch("lighthouse.helpers.plate_events.get_robot_uuid", side_effect=Exception("Boom!")):
+        test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_no_map_data_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_without_robot_uuid():
+    with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=None):
+        test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_no_map_data_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_with_failure_getting_source_plate_uuid():
+    with patch(
+        "lighthouse.helpers.plate_events.get_source_plate_uuid", side_effect=Exception("Boom!")
+    ):
+        test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_no_map_data_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_errors_without_source_plate_uuid():
+    with patch("lighthouse.helpers.plate_events.get_source_plate_uuid", return_value=None):
+        test_params = {"barcode": "ABC123", "user_id": "test_user", "robot": "12345"}
+        errors, message = construct_source_plate_no_map_data_message(test_params)
+
+        assert len(errors) == 1
+        assert message is None
+
+
+def test_construct_source_plate_no_map_data_message_creates_expected_message(app):
+    with app.app_context():
+        test_robot_uuid = "adb83afb-d59a-47f2-8d2d-7f71703ca256"
+        with patch("lighthouse.helpers.plate_events.get_robot_uuid", return_value=test_robot_uuid):
+            test_source_plate_uuid = "3a06a935-0029-49ea-81bc-e5d8eeb1319e"
+            with patch(
+                "lighthouse.helpers.plate_events.get_source_plate_uuid",
+                return_value=test_source_plate_uuid,
+            ):
+                with patch("lighthouse.helpers.plate_events.Message") as mock_message:
+                    test_barcode = "ABC123"
+                    test_user_id = "test_user"
+                    test_robot_serial_number = "12345"
+                    test_params = {
+                        "barcode": test_barcode,
+                        "user_id": test_user_id,
+                        "robot": test_robot_serial_number,
+                    }
+                    errors, _ = construct_source_plate_no_map_data_message(test_params)
+
+                    assert len(errors) == 0
+
+                    args, _ = mock_message.call_args
+                    message_content = args[0]
+
+                    assert message_content["lims"] == app.config["RMQ_LIMS_ID"]
+
+                    event = message_content["event"]
+                    assert event["uuid"] is not None
+                    assert event["event_type"] == PLATE_EVENT_SOURCE_NO_MAP_DATA
+                    assert event["occured_at"] is not None
+                    assert event["user_identifier"] == test_user_id
+
+                    subjects = event["subjects"]
+                    assert len(subjects) == 2
+                    assert {  # robot subject
+                        "role_type": "robot",
+                        "subject_type": "robot",
+                        "friendly_name": test_robot_serial_number,
+                        "uuid": test_robot_uuid,
+                    } in subjects
+                    assert {
+                        "role_type": "cherrypicking_source_labware",
+                        "subject_type": "plate",
+                        "friendly_name": test_barcode,
+                        "uuid": test_source_plate_uuid,
+                    } in subjects

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -1,5 +1,4 @@
 from lighthouse.messages.broker import Broker
-from lighthouse.messages.message import Message
 import pytest  # type: ignore
 from unittest.mock import patch, MagicMock
 

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -1,0 +1,114 @@
+from lighthouse.messages.broker import Broker
+from lighthouse.messages.message import Message
+import pytest  # type: ignore
+from unittest.mock import patch, MagicMock
+
+
+def test_broker_connect_connects(app, mock_pika):
+    with app.app_context():
+        test_credentials, test_parameters, mock_channel, mock_connection, pika = mock_pika
+
+        broker = Broker()
+        broker.connect()
+
+        pika.PlainCredentials.assert_called_with(
+            app.config["RMQ_USERNAME"], app.config["RMQ_PASSWORD"]
+        )
+        pika.ConnectionParameters.assert_called_with(
+            app.config["RMQ_HOST"],
+            app.config["RMQ_PORT"],
+            app.config["RMQ_VHOST"],
+            test_credentials,
+        )
+        pika.BlockingConnection.assert_called_with(test_parameters)
+        mock_connection.channel.assert_called()
+        mock_channel.exchange_declare.assert_called_with(
+            app.config["RMQ_EXCHANGE"], exchange_type=app.config["RMQ_EXCHANGE_TYPE"], passive=True
+        )
+
+        assert broker.connection == mock_connection
+        assert broker.channel == mock_channel
+
+
+def test_broker_publish(app, mock_pika, mock_message):
+    with app.app_context():
+        _, _, mock_channel, _, _ = mock_pika
+        test_payload, test_message = mock_message
+
+        broker = Broker()
+        broker.connect()
+        broker.publish(test_message)
+
+        mock_channel.basic_publish.assert_called_with(
+            exchange=app.config["RMQ_EXCHANGE"],
+            routing_key=app.config["RMQ_ROUTING_KEY"],
+            body=test_payload,
+        )
+
+
+def test_broker_publish_no_message(app, mock_pika):
+    with app.app_context():
+        _, _, mock_channel, _, _ = mock_pika
+
+        broker = Broker()
+        broker.connect()
+        broker.publish(None)
+
+        mock_channel.basic_publish.assert_not_called()
+
+
+def test_broker_publish_no_connection(app, mock_pika, mock_message):
+    with app.app_context():
+        _, _, mock_channel, _, _ = mock_pika
+        _, test_message = mock_message
+
+        broker = Broker()
+        with pytest.raises(AttributeError):
+            broker.publish(test_message)
+
+
+def test_broker_close_connection(app, mock_pika):
+    with app.app_context():
+        _, _, _, mock_connection, _ = mock_pika
+
+        broker = Broker()
+        broker.connect()
+        broker.close_connection()
+
+        mock_connection.close.assert_called()
+        assert broker.channel is None
+
+
+def test_broker_close_connection_no_connection():
+    broker = Broker()
+
+    with pytest.raises(AttributeError):
+        broker.close_connection()
+
+
+# class-specific test helpers
+
+
+@pytest.fixture
+def mock_pika():
+    with patch("lighthouse.messages.broker.pika") as pika:
+        test_credentials = "test credentials"
+        pika.PlainCredentials.return_value = test_credentials
+
+        test_parameters = "test parameters"
+        pika.ConnectionParameters.return_value = test_parameters
+
+        mock_channel = MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.channel.return_value = mock_channel
+        pika.BlockingConnection.return_value = mock_connection
+
+        yield test_credentials, test_parameters, mock_channel, mock_connection, pika
+
+
+@pytest.fixture
+def mock_message():
+    test_payload = "test payload"
+    test_message = MagicMock()
+    test_message.payload.return_value = test_payload
+    return test_payload, test_message

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -22,9 +22,10 @@ def test_broker_connect_connects(app, mock_pika):
         )
         pika.BlockingConnection.assert_called_with(test_parameters)
         mock_connection.channel.assert_called()
-        mock_channel.exchange_declare.assert_called_with(
-            app.config["RMQ_EXCHANGE"], exchange_type=app.config["RMQ_EXCHANGE_TYPE"], passive=True
-        )
+        if app.config["RMQ_DECLARE_EXCHANGE"]:
+            mock_channel.exchange_declare.assert_called_with(
+                app.config["RMQ_EXCHANGE"], exchange_type=app.config["RMQ_EXCHANGE_TYPE"]
+            )
 
         assert broker.connection == mock_connection
         assert broker.channel == mock_channel

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -76,7 +76,6 @@ def test_broker_close_connection(app, mock_pika):
         broker.close_connection()
 
         mock_connection.close.assert_called()
-        assert broker.channel is None
 
 
 def test_broker_close_connection_no_connection():

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -34,14 +34,15 @@ def test_broker_publish(app, mock_pika, mock_message):
     with app.app_context():
         _, _, mock_channel, _, _ = mock_pika
         test_payload, test_message = mock_message
+        test_routing_key = "routing key"
 
         broker = Broker()
         broker.connect()
-        broker.publish(test_message)
+        broker.publish(test_message, test_routing_key)
 
         mock_channel.basic_publish.assert_called_with(
             exchange=app.config["RMQ_EXCHANGE"],
-            routing_key=app.config["RMQ_ROUTING_KEY"],
+            routing_key=test_routing_key,
             body=test_payload,
         )
 
@@ -49,10 +50,24 @@ def test_broker_publish(app, mock_pika, mock_message):
 def test_broker_publish_no_message(app, mock_pika):
     with app.app_context():
         _, _, mock_channel, _, _ = mock_pika
+        test_routing_key = "routing key"
 
         broker = Broker()
         broker.connect()
         broker.publish(None)
+
+        mock_channel.basic_publish.assert_not_called()
+
+
+def test_broker_publish_no_routing_key(app, mock_pika):
+    with app.app_context():
+        _, _, mock_channel, _, _ = mock_pika
+        _, test_message = mock_message
+        test_routing_key = "routing key"
+
+        broker = Broker()
+        broker.connect()
+        broker.publish(None, test_routing_key)
 
         mock_channel.basic_publish.assert_not_called()
 
@@ -64,7 +79,7 @@ def test_broker_publish_no_connection(app, mock_pika, mock_message):
 
         broker = Broker()
         with pytest.raises(AttributeError):
-            broker.publish(test_message)
+            broker.publish(test_message, "test routing key")
 
 
 def test_broker_close_connection(app, mock_pika):

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -54,12 +54,12 @@ def test_broker_publish_no_message(app, mock_pika):
 
         broker = Broker()
         broker.connect()
-        broker.publish(None)
+        broker.publish(None, test_routing_key)
 
         mock_channel.basic_publish.assert_not_called()
 
 
-def test_broker_publish_no_routing_key(app, mock_pika):
+def test_broker_publish_no_routing_key(app, mock_pika, mock_message):
     with app.app_context():
         _, _, mock_channel, _, _ = mock_pika
         _, test_message = mock_message

--- a/tests/messages/test_broker.py
+++ b/tests/messages/test_broker.py
@@ -63,11 +63,10 @@ def test_broker_publish_no_routing_key(app, mock_pika, mock_message):
     with app.app_context():
         _, _, mock_channel, _, _ = mock_pika
         _, test_message = mock_message
-        test_routing_key = "routing key"
 
         broker = Broker()
         broker.connect()
-        broker.publish(None, test_routing_key)
+        broker.publish(test_message, None)
 
         mock_channel.basic_publish.assert_not_called()
 

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -1,0 +1,26 @@
+from lighthouse.messages.message import Message
+
+
+def test_messages_none_message():
+    message = Message(None)
+    assert message.payload() == "null"
+
+
+def test_messages_string_message():
+    message = Message("test message")
+    assert message.payload() == '"test message"'
+
+
+def test_messages_number_message():
+    message = Message(14)
+    assert message.payload() == "14"
+
+
+def test_messages_dict_message():
+    message = Message({"test key": "test value"})
+    assert message.payload() == '{"test key": "test value"}'
+
+
+def test_messages_array_message():
+    message = Message([53, "value", {"test key": "test value"}])
+    assert message.payload() == '[53, "value", {"test key": "test value"}]'


### PR DESCRIPTION
Closes #176 

Changes proposed in this pull request:

* Add framework for publishing messages to rabbit mq using pika
* Update existing plate events API endpoint to handle the 4 different plate event types:
  * construct the message based on event type, for some querying mongo for extra information
  * publish the method
