### PR TITLE
Streamline docker usage

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,3 +35,7 @@ python_version = "3.8"
 
 [pipenv]
 allow_prereleases = true
+
+[scripts]
+lint = 'black .'
+test = 'python -m pytest'

--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -1,15 +1,22 @@
 from typing import Any, Dict
+import os
+
+# If we're running in a container, then instead of localhost
+# we want host.docker.internal, you can specify this in the
+# .env file you use for docker. eg
+# LOCALHOST=host.docker.internal
+LOCALHOST = os.environ.get("LOCALHOST", "localhost")
 
 # lighthouse config
-BARACODA_URL = "localhost:5000"
-DOWNLOAD_REPORTS_URL = "http://localhost:5000/reports"
-LABWHERE_URL = "localhost:3010"
+BARACODA_URL = f"{LOCALHOST}:5000"
+DOWNLOAD_REPORTS_URL = f"http://{LOCALHOST}:5000/reports"
+LABWHERE_URL = f"{LOCALHOST}:3010"
 LIGHTHOUSE_API_KEY = "develop"
 REPORTS_DIR = "data/reports"
 
 SS_API_KEY = "develop"
-SS_HOST = "localhost:3000"
-SS_URL = "localhost:3000"
+SS_HOST = f"{LOCALHOST}:3000"
+SS_URL = f"{LOCALHOST}:3000"
 SS_UUID_PLATE_PURPOSE = ""
 SS_UUID_PLATE_PURPOSE_CHERRYPICKED = ""
 SS_UUID_STUDY = ""
@@ -17,8 +24,8 @@ SS_UUID_STUDY_CHERRYPICKED = ""
 
 EVENTS_WH_DB = "events_wh_db"
 MLWH_LIGHTHOUSE_SAMPLE_TABLE = "lighthouse_sample"
-WAREHOUSES_RO_CONN_STRING = "root@localhost"
-WAREHOUSES_RW_CONN_STRING = "root:root@localhost"
+WAREHOUSES_RO_CONN_STRING = f"root@{LOCALHOST}"
+WAREHOUSES_RW_CONN_STRING = f"root:root@{LOCALHOST}"
 
 # The window size when generating the positive samples report
 REPORT_WINDOW_SIZE = 2
@@ -80,7 +87,7 @@ DOMAIN: Dict = {
     "schema": {},
 }
 
-MONGO_HOST = "localhost"
+MONGO_HOST = f"{LOCALHOST}"
 MONGO_PORT = 27017
 MONGO_USERNAME = ""
 MONGO_PASSWORD = ""
@@ -121,7 +128,7 @@ LOGGING: Dict[str, Any] = {
 DART_RESULT_VIEW = "CherrypickingInfo"
 BARACODA_RETRY_ATTEMPTS = 3
 
-RMQ_HOST = "localhost"
+RMQ_HOST = f"{LOCALHOST}"
 RMQ_PORT = 5672
 RMQ_USERNAME = "guest"
 RMQ_PASSWORD = "guest"

--- a/lighthouse/config/development.py
+++ b/lighthouse/config/development.py
@@ -6,20 +6,20 @@ from lighthouse.config.defaults import *  # noqa: F403, F401
 SCHEDULER_RUN = False
 
 # Eve config
-MONGO_HOST = "127.0.0.1"
+MONGO_HOST = f"{LOCALHOST}"
 MONGO_DBNAME = "lighthouseDevelopmentDB"
 
 # logging config
 LOGGING["loggers"]["lighthouse"]["level"] = "DEBUG"  # noqa: F405
 LOGGING["loggers"]["lighthouse"]["handlers"] = ["colored_stream"]  # noqa: F405
 
-WAREHOUSES_RO_CONN_STRING = "root@localhost"
+WAREHOUSES_RO_CONN_STRING = f"root@{LOCALHOST}"
 ML_WH_DB = "unified_warehouse_test"
 
-WAREHOUSES_RW_CONN_STRING = "root:root@localhost"
+WAREHOUSES_RW_CONN_STRING = f"root:root@{LOCALHOST}"
 MLWH_LIGHTHOUSE_SAMPLE_TABLE = "lighthouse_sample"
 
-DART_SQL_SERVER_HOST = "localhost"
+DART_SQL_SERVER_HOST = f"{LOCALHOST}"
 DART_SQL_SERVER_DATABASE = "DartTestDB"
 DART_SQL_SERVER_USER = "SA"
 DART_SQL_SERVER_PASSWORD = "MyS3cr3tPassw0rd"

--- a/lighthouse/config/test.py
+++ b/lighthouse/config/test.py
@@ -9,7 +9,7 @@ TESTING = True
 SCHEDULER_RUN = False
 
 # Eve config
-MONGO_HOST = "127.0.0.1"
+MONGO_HOST = f"{LOCALHOST}"
 MONGO_DBNAME = "lighthouseTestDB"
 MONGO_QUERY_BLACKLIST = ["$where"]  # not sure why this was required...
 
@@ -19,14 +19,14 @@ LOGGING["loggers"]["lighthouse"]["handlers"] = ["colored_stream"]  # noqa: F405
 
 REPORTS_DIR = "tests/data/reports"
 
-WAREHOUSES_RO_CONN_STRING = "root@localhost"
+WAREHOUSES_RO_CONN_STRING = f"root@{LOCALHOST}"
 ML_WH_DB = "unified_warehouse_test"
 EVENTS_WH_DB = "event_warehouse_test"
 
-WAREHOUSES_RW_CONN_STRING = "root@localhost"
+WAREHOUSES_RW_CONN_STRING = f"root@{LOCALHOST}"
 MLWH_LIGHTHOUSE_SAMPLE_TABLE = "lighthouse_sample"
 
-DART_SQL_SERVER_HOST = "localhost"
+DART_SQL_SERVER_HOST = f"{LOCALHOST}"
 DART_SQL_SERVER_DATABASE = "DartTestDB"
 DART_SQL_SERVER_USER = "SA"
 DART_SQL_SERVER_PASSWORD = "MyS3cr3tPassw0rd"
@@ -49,7 +49,7 @@ EVENT_WH_EVENT_TYPES_TABLE = "event_types"
 EVENT_WH_SUBJECT_TYPES_TABLE = "subject_types"
 EVENT_WH_ROLE_TYPES_TABLE = "role_types"
 
-RMQ_HOST = "localhost"
+RMQ_HOST = f"{LOCALHOST}"
 RMQ_PORT = 5672
 RMQ_USERNAME = "guest"
 RMQ_PASSWORD = "guest"

--- a/setup_sqlserver_test_db.py
+++ b/setup_sqlserver_test_db.py
@@ -1,9 +1,12 @@
 import pyodbc  # type: ignore
+import os
+
+LOCALHOST = os.environ.get("LOCALHOST", "localhost")
 
 cnxn = pyodbc.connect(
     (
         "DRIVER={ODBC Driver 17 for SQL Server};"  # noqa: F541
-        "SERVER=tcp:localhost;"
+        f"SERVER=tcp:{LOCALHOST};"
         "DATABASE=master;UID=SA;PWD=MyS3cr3tPassw0rd"
     ),
     autocommit=True,


### PR DESCRIPTION
Docker requires localhost to be replace with
host.docker.internal. This change lets it
be injected in via an environmental variable,
removing the need to modify the config.
