### PR TITLE
issue194/gpl 753 create labwhere records for source and control plates on beckman

### DIFF
--- a/lighthouse/config/defaults.py
+++ b/lighthouse/config/defaults.py
@@ -11,6 +11,9 @@ LOCALHOST = os.environ.get("LOCALHOST", "localhost")
 BARACODA_URL = f"{LOCALHOST}:5000"
 DOWNLOAD_REPORTS_URL = f"http://{LOCALHOST}:5000/reports"
 LABWHERE_URL = f"{LOCALHOST}:3010"
+LABWHERE_DESTROYED_BARCODE = os.environ.get(
+    "LABWHERE_DESTROYED_BARCODE", "lw-heron-destroyed-17338"
+)
 LIGHTHOUSE_API_KEY = "develop"
 REPORTS_DIR = "data/reports"
 

--- a/lighthouse/config/test.py
+++ b/lighthouse/config/test.py
@@ -13,6 +13,9 @@ MONGO_HOST = f"{LOCALHOST}"
 MONGO_DBNAME = "lighthouseTestDB"
 MONGO_QUERY_BLACKLIST = ["$where"]  # not sure why this was required...
 
+# Labwhere Config
+LABWHERE_DESTROYED_BARCODE = "heron-bin"
+
 # logging config
 LOGGING["loggers"]["lighthouse"]["level"] = "DEBUG"  # noqa: F405
 LOGGING["loggers"]["lighthouse"]["handlers"] = ["colored_stream"]  # noqa: F405

--- a/lighthouse/constants.py
+++ b/lighthouse/constants.py
@@ -89,7 +89,12 @@ POSITIVE_SAMPLES_MONGODB_FILTER = {
     ],
 }
 
+# Events detailed in https://ssg-confluence.internal.sanger.ac.uk/display/PSDPUB/Cherrypicking+Events
+# Source plate has had all pickable wells cherrypicked into destination plates, and the plate is put into the output stacks.
 PLATE_EVENT_SOURCE_COMPLETED = "lh_beckman_cp_source_completed"
+# Source plate barcode cannot be read (damaged or missing), and the plate is put into the output stacks.
 PLATE_EVENT_SOURCE_NOT_RECOGNISED = "lh_beckman_cp_source_plate_unrecognised"
+# Source plate has no related plate map data, cannot be cherrypicked (yet), and the plate is returned to the input stacks.
 PLATE_EVENT_SOURCE_NO_MAP_DATA = "lh_beckman_cp_source_no_plate_map_data"
+# Source plate only contains negatives, nothing to cherrypick, and the plate is put into the output stacks.
 PLATE_EVENT_SOURCE_ALL_NEGATIVES = "lh_beckman_cp_source_all_negatives"

--- a/lighthouse/helpers/labwhere.py
+++ b/lighthouse/helpers/labwhere.py
@@ -38,7 +38,7 @@ def set_locations_in_labwhere(
     Arguments:
         labware_barcodes {List[str]} - The source plate barcodes
         location_barcode {str} - The barcode of the locations to which the labwares have been transferred.
-        user_barcode {str} - The swipecard/barcode for the user or robot associate with the scan.
+        user_barcode {str} - The swipecard/barcode for the user or robot associated with the scan.
 
 
     Returns:

--- a/lighthouse/helpers/labwhere.py
+++ b/lighthouse/helpers/labwhere.py
@@ -2,7 +2,8 @@
 
 This file contains the following functions:
 
-  * get_locations_from_labwhere - Make an API call to labwhere
+  * get_locations_from_labwhere - Make an API call to labwhere to get locations
+  * set_locations_in_labwhere - Make an API call to labwhere to update locations
 """
 
 import requests

--- a/lighthouse/helpers/labwhere.py
+++ b/lighthouse/helpers/labwhere.py
@@ -1,0 +1,23 @@
+"""Connect to labwhere to update or retrieve location information
+
+This file contains the following functions:
+
+  * get_locations_from_labwhere - Make an API call to labwhere
+"""
+
+import requests
+from flask import current_app as app
+from typing import List
+
+
+def get_locations_from_labwhere(labware_barcodes):
+    """Retrieve a location from labwhere
+    Example record from labwhere:
+    { 'barcode': 'GLA001024R', 'location_barcode': 'lw-uk-biocentre-box-gsw--98-14813'}
+    """
+
+    return requests.post(
+        f"http://{app.config['LABWHERE_URL']}/api/labwares_by_barcode",
+        json={"barcodes": labware_barcodes},
+    )
+

--- a/lighthouse/helpers/labwhere.py
+++ b/lighthouse/helpers/labwhere.py
@@ -21,3 +21,37 @@ def get_locations_from_labwhere(labware_barcodes):
         json={"barcodes": labware_barcodes},
     )
 
+
+def set_locations_in_labwhere(
+    labware_barcodes: List[str], location_barcode: str, user_barcode: str
+):
+    """Record a scan event in labwhere for labware_barcodes
+
+    Note: The labwhere API currently identifies users by their swipecard, however
+    currently we only have access to the login when generating plate events.
+    We can use the robot as a user instead, this has the advantage that:
+      1) Its not open to user error
+      2) There is reduced risk that the robot is not registered in labwhere
+      3) We wont ascribe unloading the robot to the same user who loaded it
+      4) It will not require changes to labwhere or additional user id validation
+
+    Arguments:
+        labware_barcodes {List[str]} - The source plate barcodes
+        location_barcode {str} - The barcode of the locations to which the labwares have been transferred.
+        user_barcode {str} - The swipecard/barcode for the user or robot associate with the scan.
+
+
+    Returns:
+        {requests.Response} -- The labwhere response object
+    """
+
+    return requests.post(
+        f"http://{app.config['LABWHERE_URL']}/api/scans",
+        json={
+            "scan": {
+                "user_code": user_barcode,
+                "labware_barcodes": "\n".join(labware_barcodes),
+                "location_barcode": location_barcode,
+            }
+        },
+    )

--- a/lighthouse/helpers/plate_event_callbacks.py
+++ b/lighthouse/helpers/plate_event_callbacks.py
@@ -72,7 +72,7 @@ def _labwhere_transfer_to_bin(event: Message) -> Tuple[bool, List]:
 
 
 def _labwhere_destroyed_barcode() -> str:
-    """The barcode associated with the detroyed labware location in labwhere
+    """The barcode associated with the destroyed labware location in labwhere
 
     As this value can vary between environments, it is part of the app context
     and is configures in config/defaults.py or the appropriate environment file.

--- a/lighthouse/helpers/plate_event_callbacks.py
+++ b/lighthouse/helpers/plate_event_callbacks.py
@@ -1,0 +1,107 @@
+"""Handle callbacks for registered event types
+
+Event callbacks are additional actions that will be triggered following the
+creation of an event. They are triggered by passing a Message to
+fire_callbacks.
+
+Callbacks are registered in the dictionary EVENT_TYPE_CALLBACKS, which should
+map an event_type to a callback function. Event types without callbacks
+registered will invoke _no_callback, which does nothing.
+
+Callbacks should return a Tuple[bool, List[str]] where the boolean indicates
+success, and the list contains any errors. Note that success indicates that
+the callback was processed correctly, not that it necessarily performed an
+action. For example the default _no_callback still returns a success,
+despite not doing anything, as this is the correct action for event types
+without callbacks.
+
+This file contains the following functions:
+
+  * fire_callbacks - fires the callbacks for the passed message
+"""
+
+import logging
+from lighthouse.messages.message import Message
+from typing import Tuple, List
+from lighthouse.constants import (
+    PLATE_EVENT_SOURCE_COMPLETED,
+    PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+)
+from lighthouse.helpers.labwhere import set_locations_in_labwhere
+from flask import current_app as app
+
+logger = logging.getLogger(__name__)
+
+
+def fire_callbacks(event: Message) -> Tuple[bool, List[str]]:
+    """Fire any callbacks set up for a particular event type
+
+    Arguments:
+        event {Message} -- The event for which to fire a callback
+
+    Returns:
+        {bool} -- True if the operation completed successfully
+        {[str]} -- Any errors attempting to construct the message, otherwise an empty array.
+    """
+    event_type = event.event_type()
+    callback = EVENT_TYPE_CALLBACKS.get(event_type, _no_callback)
+    return callback(event)
+
+
+def _no_callback(event: Message) -> Tuple[bool, List]:
+    """Do nothing, but return a success"""
+    logger.debug("_no_callback")
+    return True, []
+
+
+def _labwhere_transfer_to_bin(event: Message) -> Tuple[bool, List]:
+    """Record a transfer of the cherrypicking_source_labware to the bin"""
+    logger.debug("_labwhere_transfer_to_bin")
+    try:
+        labware_barcodes = _labware_barcodes(event)
+        location_barcode = _labwhere_destroyed_barcode()
+        robot_barcode = _robot_barcode(event)
+        set_locations_in_labwhere(
+            labware_barcodes=labware_barcodes,
+            location_barcode=location_barcode,
+            user_barcode=robot_barcode,
+        )
+        return True, []
+    except Exception as e:
+        return False, [f"{type(e).__name__}: {str(e)}"]
+
+
+def _labwhere_destroyed_barcode() -> str:
+    """The barcode associated with the detroyed labware location in labwhere
+
+    As this value can vary between environments, it is part of the app context
+    and is configures in config/defaults.py or the appropriate environment file.
+    You can also specify the barcode in the LABWHERE_DESTROYED_BARCODE
+    environmental variable, which is useful in development mode.
+    """
+    return app.config["LABWHERE_DESTROYED_BARCODE"]
+
+
+def _labware_barcodes(event: Message) -> List[str]:
+    """Extracts cherrypicking_source_labware barcodes from an event message"""
+    return [
+        subject["friendly_name"]
+        for subject in event.message["event"]["subjects"]
+        if subject["role_type"] == "cherrypicking_source_labware"
+    ]
+
+
+def _robot_barcode(event: Message) -> str:
+    """Extracts a robot barcode from an event message"""
+    return next(
+        subject["friendly_name"]
+        for subject in event.message["event"]["subjects"]
+        if subject["role_type"] == "robot"
+    )
+
+
+# Maps each event_type to a callback function
+EVENT_TYPE_CALLBACKS = {
+    PLATE_EVENT_SOURCE_ALL_NEGATIVES: _labwhere_transfer_to_bin,
+    PLATE_EVENT_SOURCE_COMPLETED: _labwhere_transfer_to_bin,
+}

--- a/lighthouse/helpers/plate_event_callbacks.py
+++ b/lighthouse/helpers/plate_event_callbacks.py
@@ -21,7 +21,7 @@ This file contains the following functions:
 """
 
 import logging
-from lighthouse.messages.message import Message
+from lighthouse.messages.message import Message # type: ignore
 from typing import Tuple, List
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
@@ -48,13 +48,13 @@ def fire_callbacks(event: Message) -> Tuple[bool, List[str]]:
     return callback(event)
 
 
-def _no_callback(event: Message) -> Tuple[bool, List]:
+def _no_callback(event: Message) -> Tuple[bool, List[str]]:
     """Do nothing, but return a success"""
     logger.debug("_no_callback")
     return True, []
 
 
-def _labwhere_transfer_to_bin(event: Message) -> Tuple[bool, List]:
+def _labwhere_transfer_to_bin(event: Message) -> Tuple[bool, List[str]]:
     """Record a transfer of the cherrypicking_source_labware to the bin"""
     logger.debug("_labwhere_transfer_to_bin")
     try:

--- a/lighthouse/helpers/plate_event_callbacks.py
+++ b/lighthouse/helpers/plate_event_callbacks.py
@@ -21,7 +21,7 @@ This file contains the following functions:
 """
 
 import logging
-from lighthouse.messages.message import Message # type: ignore
+from lighthouse.messages.message import Message  # type: ignore
 from typing import Tuple, List
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,

--- a/lighthouse/helpers/reports.py
+++ b/lighthouse/helpers/reports.py
@@ -6,9 +6,9 @@ import re
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import Dict, List, Tuple
+from lighthouse.helpers.labwhere import get_locations_from_labwhere
 
 import pandas as pd  # type: ignore
-import requests
 import sqlalchemy  # type: ignore
 from flask import current_app as app
 from lighthouse.constants import (
@@ -161,18 +161,6 @@ def map_labware_to_location(labware_barcodes):
     pretty(logger, labware_to_location_barcode_df)
 
     return labware_to_location_barcode_df
-
-
-def get_locations_from_labwhere(labware_barcodes):
-    """
-    Example record from labwhere:
-    { 'barcode': 'GLA001024R', 'location_barcode': 'lw-uk-biocentre-box-gsw--98-14813'}
-    """
-
-    return requests.post(
-        f"http://{app.config['LABWHERE_URL']}/api/labwares_by_barcode",
-        json={"barcodes": labware_barcodes},
-    )
 
 
 def get_cherrypicked_samples(root_sample_ids, plate_barcodes, chunk_size=50000):

--- a/lighthouse/messages/message.py
+++ b/lighthouse/messages/message.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 
 class Message:
@@ -14,3 +15,14 @@ class Message:
             {str} -- The message JSON payload.
         """
         return json.dumps(self.message)
+
+    def event_type(self) -> str:
+        """Return the event type.
+
+        Returns a string representing the event type. Throws a KeyError if
+        either event is not present in the root of the message, or if the
+        event type key is missing. This will usually indicate that we are
+        attempting to process a non event message.
+        """
+
+        return self.message["event"]["event_type"]

--- a/tests/blueprints/test_plate_events.py
+++ b/tests/blueprints/test_plate_events.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from unittest.mock import patch
-from lighthouse.messages.message import Message # type: ignore
+from lighthouse.messages.message import Message  # type: ignore
 
 
 def test_get_create_plate_event_endpoint_bad_request_no_event_type(client):

--- a/tests/blueprints/test_plate_events.py
+++ b/tests/blueprints/test_plate_events.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from unittest.mock import patch
-from lighthouse.messages.message import Message
+from lighthouse.messages.message import Message # type: ignore
 
 
 def test_get_create_plate_event_endpoint_bad_request_no_event_type(client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,16 @@ from .data.fixture_data import (
     MLWH_SAMPLE_STOCK_RESOURCE,
     SOURCE_PLATES,
 )
+
+from lighthouse.constants import (
+    PLATE_EVENT_SOURCE_COMPLETED,
+    PLATE_EVENT_SOURCE_NO_MAP_DATA,
+    PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+)
 from lighthouse.helpers.mysql_db import create_mysql_connection_engine, get_table
 from lighthouse.helpers.dart_db import create_dart_connection, load_sql_server_script
+
+from lighthouse.messages.message import Message  # type: ignore
 
 
 @pytest.fixture
@@ -405,3 +413,83 @@ def samples_with_uuids(app):
     # clear up after the fixture is used
     with app.app_context():
         samples_collection.delete_many({})
+
+
+@pytest.fixture
+def message_unknown():
+    message_content = {
+        "event": {
+            "uuid": "1770dbcd-0abf-4293-ac62-dd26964f80b0",
+            "event_type": "no_callbacks",
+            "occured_at": "2020-11-26T15:58:20",
+            "user_identifier": "test1",
+            "subjects": [],
+            "metadata": {},
+        },
+        "lims": "LH_TEST",
+    }
+    return Message(message_content)
+
+
+@pytest.fixture
+def message_source_complete():
+    message_content = {
+        "event": {
+            "uuid": "1770dbcd-0abf-4293-ac62-dd26964f80b0",
+            "event_type": PLATE_EVENT_SOURCE_COMPLETED,
+            "occured_at": "2020-11-26T15:58:20",
+            "user_identifier": "test1",
+            "subjects": [
+                {
+                    "role_type": "sample",
+                    "subject_type": "sample",
+                    "friendly_name": "friendly_name",
+                    "uuid": "00000000-1111-2222-3333-555555555555",
+                },
+                {
+                    "role_type": "cherrypicking_source_labware",
+                    "subject_type": "plate",
+                    "friendly_name": "plate-barcode",
+                    "uuid": "00000000-1111-2222-3333-555555555556",
+                },
+                {
+                    "role_type": "robot",
+                    "subject_type": "robot",
+                    "friendly_name": "robot-serial",
+                    "uuid": "00000000-1111-2222-3333-555555555557",
+                },
+            ],
+            "metadata": {},
+        },
+        "lims": "LH_TEST",
+    }
+    return Message(message_content)
+
+
+@pytest.fixture
+def message_source_all_negative():
+    message_content = {
+        "event": {
+            "uuid": "1770dbcd-0abf-4293-ac62-dd26964f80b0",
+            "event_type": PLATE_EVENT_SOURCE_ALL_NEGATIVES,
+            "occured_at": "2020-11-26T15:58:20",
+            "user_identifier": "test1",
+            "subjects": [
+                {
+                    "role_type": "cherrypicking_source_labware",
+                    "subject_type": "plate",
+                    "friendly_name": "plate-barcode",
+                    "uuid": "00000000-1111-2222-3333-555555555556",
+                },
+                {
+                    "role_type": "robot",
+                    "subject_type": "robot",
+                    "friendly_name": "robot-serial",
+                    "uuid": "00000000-1111-2222-3333-555555555557",
+                },
+            ],
+            "metadata": {},
+        },
+        "lims": "LH_TEST",
+    }
+    return Message(message_content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ from .data.fixture_data import (
 
 from lighthouse.constants import (
     PLATE_EVENT_SOURCE_COMPLETED,
-    PLATE_EVENT_SOURCE_NO_MAP_DATA,
     PLATE_EVENT_SOURCE_ALL_NEGATIVES,
 )
 from lighthouse.helpers.mysql_db import create_mysql_connection_engine, get_table

--- a/tests/helpers/test_labwhere_helpers.py
+++ b/tests/helpers/test_labwhere_helpers.py
@@ -1,0 +1,12 @@
+from lighthouse.helpers.labwhere import get_locations_from_labwhere, set_locations_in_labwhere
+import responses  # type: ignore
+from http import HTTPStatus
+import json
+
+
+def test_get_locations_from_labwhere(app, labwhere_samples_simple):
+    with app.app_context():
+        response = get_locations_from_labwhere("123")
+        assert response.json() == [{"barcode": "123", "location_barcode": "4567"}]
+
+

--- a/tests/helpers/test_labwhere_helpers.py
+++ b/tests/helpers/test_labwhere_helpers.py
@@ -10,3 +10,33 @@ def test_get_locations_from_labwhere(app, labwhere_samples_simple):
         assert response.json() == [{"barcode": "123", "location_barcode": "4567"}]
 
 
+def test_set_locations_in_labwhere(app, mocked_responses):
+    with app.app_context():
+        labwhere_url = f"http://{app.config['LABWHERE_URL']}/api/scans"
+        # The expected payload sent to labwhere
+        payload = {
+            "scan": {
+                "user_code": "robot-1",
+                "labware_barcodes": "123",
+                "location_barcode": "location-1-1",
+            }
+        }
+        # The expected response. In practice its a bit bigger, but I don't think
+        # we especially care.
+        body = json.dumps(
+            {
+                "message": "1 Labwares scanned in to location 1",
+                "location": {"name": "Location 1", "barcode": "location-1-1"},
+            }
+        )
+
+        mocked_responses.add(
+            responses.POST,
+            labwhere_url,
+            match=[responses.json_params_matcher(payload)],
+            body=body,
+            status=HTTPStatus.OK,
+        )
+
+        response = set_locations_in_labwhere(["123"], "location-1-1", "robot-1")
+        assert response

--- a/tests/helpers/test_plate_event_callback_helpers.py
+++ b/tests/helpers/test_plate_event_callback_helpers.py
@@ -1,0 +1,65 @@
+from lighthouse.messages.message import Message  # type: ignore
+from lighthouse.helpers.plate_event_callbacks import fire_callbacks
+from unittest.mock import patch, MagicMock
+
+
+def test_fire_callbacks_unrecognised_event(app, message_unknown):
+    with app.app_context():
+        success, errors = fire_callbacks(message_unknown)
+
+        assert len(errors) == 0
+        assert success is True
+
+
+def test_fire_callbacks_with_failure(app, message_source_all_negative):
+    with app.app_context():
+        with patch(
+            "lighthouse.helpers.plate_event_callbacks.set_locations_in_labwhere",
+            side_effect=Exception("Labwhere was down"),
+        ) as mock_set_locations_in_labwhere:
+            success, errors = fire_callbacks(message_source_all_negative)
+
+            assert len(errors) == 1
+            assert errors[0] == "Exception: Labwhere was down"
+            assert success is False
+
+
+def test_fire_callbacks_source_all_negatives(app, message_source_all_negative):
+    with app.app_context():
+        with patch(
+            "lighthouse.helpers.plate_event_callbacks.set_locations_in_labwhere"
+        ) as mock_set_locations_in_labwhere:
+            success, errors = fire_callbacks(message_source_all_negative)
+
+            mock_set_locations_in_labwhere.assert_called_with(
+                labware_barcodes=["plate-barcode"],
+                location_barcode="heron-bin",
+                user_barcode="robot-serial",
+            )
+
+            assert len(errors) == 0
+            assert success is True
+
+
+def test_fire_callbacks_source_fully_picked(app, message_source_complete):
+    with app.app_context():
+        with patch(
+            "lighthouse.helpers.plate_event_callbacks.set_locations_in_labwhere"
+        ) as mock_set_locations_in_labwhere:
+            success, errors = fire_callbacks(message_source_complete)
+
+            mock_set_locations_in_labwhere.assert_called_with(
+                labware_barcodes=["plate-barcode"],
+                location_barcode="heron-bin",
+                user_barcode="robot-serial",
+            )
+
+            assert len(errors) == 0
+            assert success is True
+
+
+# TODO: test_fire_callbacks_control_plate_used
+#       It is currently unclear which event to use for this.
+#       We *Could* use the destination complete event, and extract
+#       the information from the control sample friendly name but
+#       there may be a more robust approach

--- a/tests/helpers/test_reports_helpers.py
+++ b/tests/helpers/test_reports_helpers.py
@@ -23,7 +23,6 @@ from lighthouse.helpers.reports import (
     get_distinct_plate_barcodes,
     get_new_report_name_and_path,
     join_samples_declarations,
-    map_labware_to_location,
     report_query_window_start,
     unpad_coordinate,
 )
@@ -171,33 +170,6 @@ def test_query_by_ct_limit(app, freezer, samples_ct_values):
         ct_less_than_limit = samples.count_documents({FIELD_CH1_CQ: {"$lte": CT_VALUE_LIMIT}})
 
         assert ct_less_than_limit == 1  # 'MCM003'
-
-
-def test_map_labware_to_location_labwhere_error(app, freezer, labwhere_samples_error):
-    # mocks response from get_locations_from_labwhere() with labwhere_samples_error
-
-    raised_exception = False
-
-    try:
-        with app.app_context():
-            map_labware_to_location(["test"])
-    except ReportCreationError:
-        raised_exception = True
-
-    assert raised_exception
-
-
-def test_map_labware_to_location_dataframe_content(app, freezer, labwhere_samples_multiple):
-    # mocks response from get_locations_from_labwhere() with labwhere_samples_multiple
-    with app.app_context():
-        result = map_labware_to_location(
-            ["123", "456", "789"]
-        )  # '789' returns no location, in the mock
-
-    expected_columns = [FIELD_PLATE_BARCODE, "location_barcode"]
-    expected_data = [["123", "4567"], ["456", "1234"], ["789", ""]]
-    assert result.columns.to_list() == expected_columns
-    assert np.array_equal(result.to_numpy(), expected_data)
 
 
 def test_add_cherrypicked_column(app, freezer):


### PR DESCRIPTION
Adds tracking source plate locations

Note:
This PR does *not* cover the updating of the control plate location
as currently there is not a corresponding event. See issue #194 for further
information.

- Streamline docker usage
- Document event constants
- Refactor labwhere methods into own module
- Add labwhere set location method
- Add event callbacks
- Invoke callbacks after event creation
