### PR TITLE
View query - ignore old runs, null checks

### DIFF
--- a/lighthouse/helpers/dart_db.py
+++ b/lighthouse/helpers/dart_db.py
@@ -8,6 +8,7 @@ from lighthouse.constants import (
     FIELD_DART_LAB_ID,
     FIELD_DART_RNA_ID,
     FIELD_DART_ROOT_SAMPLE_ID,
+    FIELD_DART_RUN_ID,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,9 +24,16 @@ def get_samples_for_barcode(cnxn, barcode):
         f"SELECT * FROM {app.config['DART_RESULT_VIEW']}"
         f" WHERE [{FIELD_DART_DESTINATION_BARCODE}]='{barcode}'"
         f" AND (([{FIELD_DART_ROOT_SAMPLE_ID}] IS NOT NULL"
+        f" AND [{FIELD_DART_ROOT_SAMPLE_ID}]<>''"
         f" AND [{FIELD_DART_RNA_ID}] IS NOT NULL"
-        f" AND [{FIELD_DART_LAB_ID}] IS NOT NULL)"
-        f" OR [{FIELD_DART_CONTROL}] IS NOT NULL);"
+        f" AND [{FIELD_DART_RNA_ID}]<>''"
+        f" AND [{FIELD_DART_LAB_ID}] IS NOT NULL"
+        f" AND [{FIELD_DART_LAB_ID}]<>'')"
+        f" OR ([{FIELD_DART_CONTROL}] IS NOT NULL AND [{FIELD_DART_CONTROL}]<>''))"
+        f" AND [{FIELD_DART_RUN_ID}]=("
+        f"  SELECT MAX([{FIELD_DART_RUN_ID}])"
+        f"  FROM {app.config['DART_RESULT_VIEW']}"
+        f"  WHERE [{FIELD_DART_DESTINATION_BARCODE}]='{barcode}');"
     )
     rows = cursor.fetchall()
     return rows

--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -459,7 +459,7 @@ def create_cherrypicked_post_body(
         if FIELD_SS_CONTROL in sample:
             content[FIELD_SS_SUPPLIER_NAME] = sample[FIELD_SS_SUPPLIER_NAME]
             content[FIELD_SS_CONTROL] = sample[FIELD_SS_CONTROL]
-            content[FIELD_SS_CONTROL_TYPE] = sample[FIELD_SS_CONTROL_TYPE]
+            content[FIELD_SS_CONTROL_TYPE] = sample[FIELD_SS_CONTROL_TYPE].lower()
             content[FIELD_SS_UUID] = sample[FIELD_SS_UUID]
         else:
             content[FIELD_SS_NAME] = sample[FIELD_SS_NAME]

--- a/tests/data/dart/seed.sql
+++ b/tests/data/dart/seed.sql
@@ -2,7 +2,8 @@ delete from CherrypickingInfo;
 
 INSERT INTO CherrypickingInfo
 VALUES
-  (1, 'test1', 'A01', '123', 'A01', NULL, 'MCM001', 'rna_1', 'Lab 1'),
-  (2, 'test1', 'B01', '456', 'A01', NULL, 'MCM002', 'rna_2', 'Lab 2'),
-  (2, 'test1', 'C01', '789', 'B01', 'positive', NULL, NULL, NULL),
+  (2, 'test1', 'A01', 'this_line_will_be_ignored', 'A01', NULL, 'MCM001', 'rna_1', 'Lab 1'),
+  (3, 'test1', 'A01', '123', 'A01', NULL, 'MCM001', 'rna_1', 'Lab 1'),
+  (3, 'test1', 'B01', '456', 'A01', NULL, 'MCM002', 'rna_2', 'Lab 2'),
+  (3, 'test1', 'C01', '789', 'B01', 'positive', NULL, NULL, NULL),
   (3, 'test1', 'C01', '789', 'C01', NULL, NULL, NULL, NULL);

--- a/tests/data/dart/seed_for_bp_test.sql
+++ b/tests/data/dart/seed_for_bp_test.sql
@@ -2,6 +2,7 @@ delete from CherrypickingInfo;
 
 INSERT INTO CherrypickingInfo
 VALUES
-  (1, 'plate_1', 'A01', '123', 'A01', NULL, 'MCM001', 'rna_1', 'Lab 1'),
+  (1, 'plate_1', 'D01', 'this_line_will_be_ignored', 'A01', NULL, 'MCM007', 'rna_1', 'Lab 1'),
+  (2, 'plate_1', 'A01', '123', 'A01', NULL, 'MCM001', 'rna_1', 'Lab 1'),
   (2, 'plate_1', 'B01', '123', 'F01', NULL, 'MCM006', 'rna_1', 'Lab 1'),
   (2, 'plate_1', 'C01', '789', 'B01', 'positive', NULL, NULL, NULL);

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -755,7 +755,7 @@ def test_create_cherrypicked_post_body(app):
                         "B01": {
                             "content": {
                                 FIELD_SS_CONTROL: True,
-                                FIELD_SS_CONTROL_TYPE: "Positive",
+                                FIELD_SS_CONTROL_TYPE: "positive",
                                 FIELD_SS_SUPPLIER_NAME: "Positive control: 123_B01",
                                 FIELD_SS_UUID: "71c71e3b-5c85-4d5c-831e-bee7bdd06c53",
                             }


### PR DESCRIPTION
In the interest in getting prod in a state where we could go live with Beckman stuff at short notice if needed -

Cherrypicked 70e6e45 so can release now, without taking the other changes in develop with it. 

Original commit message:
* Ignore old runs
* Ignore entries that do contain an empty string
* Fixed bracket position
* Lowercase of control type