### PR TITLE
changed /plates barcodes params to be a list of comma seperated values

### DIFF
--- a/lighthouse/blueprints/plates.py
+++ b/lighthouse/blueprints/plates.py
@@ -97,28 +97,33 @@ def create_plate_from_barcode() -> FlaskResponse:
 
 @bp.get("/plates")
 def find_plate_from_barcode() -> FlaskResponse:
-    """A route which returns information about a list of plates as specified in the 'barcodes[]' parameters.
+    """A route which returns information about a list of comma separated plates as specified in the 'barcodes' parameters.
 
     For example:
     To fetch data for the plates with barcodes '123', '456' and '789':
 
-    `GET /plates?barcodes[]=123&barcodes[]=456&barcodes[]=789`
+    `GET /plates?barcodes=123,456,789`
 
     This endpoint responds with JSON and the body is in the format:
 
-    `{"plates":[{"barcode":"123","plate_map":true,"number_of_fit_to_pick":0}]}`
+    `{"plates":[
+        {"barcode":"123","plate_map":true,"number_of_fit_to_pick":0},
+        {"barcode":"456","plate_map":true,"number_of_fit_to_pick":0},
+        {"barcode":"789","plate_map":true,"number_of_fit_to_pick":0}
+    }`
 
     Returns:
         FlaskResponse: the response body and HTTP status code
     """
     logger.info("Finding plate from barcode")
     try:
-        barcodes = request.args.getlist("barcodes[]")
+        barcodes = request.args.get("barcodes")
         logger.debug(f"Barcodes to look for: {barcodes}")
 
+        barcodes_list = barcodes.split(",")
         include_samples = request.args.get("include_samples") == "true"
 
-        plates = [format_plate(barcode, include_samples) for barcode in barcodes]
+        plates = [format_plate(barcode, include_samples) for barcode in barcodes_list]
 
         pretty(logger, plates)
 

--- a/tests/blueprints/test_plates.py
+++ b/tests/blueprints/test_plates.py
@@ -81,7 +81,7 @@ def test_post_plates_mlwh_update_failure(app, client, samples, mocked_responses)
 def test_get_plates_endpoint_successful(
     app, client, samples, priority_samples, mocked_responses, plates_lookup_without_samples
 ):
-    response = client.get("/plates?barcodes[]=plate_123&barcodes[]=456", content_type="application/json")
+    response = client.get("/plates?barcodes=plate_123,456", content_type="application/json")
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == {
@@ -95,21 +95,21 @@ def test_get_plates_endpoint_successful(
                 "count_must_sequence": 0,
                 "count_preferentially_sequence": 0,
             },
-        ]
+    ]
     }
 
 
 def test_get_plates_endpoint_method_calls(app, client, samples, priority_samples):
     barcode = "plate_123"
     with patch("lighthouse.helpers.plates.has_plate_map_data", return_value=True) as mock_has_plate_map_data:
-        response = client.get(f"/plates?barcodes[]={barcode}", content_type="application/json")
+        response = client.get(f"/plates?barcodes={barcode}", content_type="application/json")
         assert response.status_code == HTTPStatus.OK
         mock_has_plate_map_data.assert_called_once_with(barcode)
 
 
 def test_get_plates_endpoint_fail(app, client, samples, mocked_responses):
     with patch("lighthouse.helpers.plates.get_fit_to_pick_samples_and_counts", side_effect=Exception()):
-        response = client.get("/plates?barcodes[]=123&barcodes[]=456", content_type="application/json")
+        response = client.get("/plates?barcodes=123,456", content_type="application/json")
 
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         assert response.json == {"errors": ["Failed to lookup plates: Exception"]}
@@ -118,9 +118,7 @@ def test_get_plates_endpoint_fail(app, client, samples, mocked_responses):
 def test_get_plates_endpoint_include_samples(
     app, client, samples, priority_samples, mocked_responses, plates_lookup_with_samples
 ):
-    response = client.get(
-        "/plates?barcodes[]=plate_123&barcodes[]=456&include_samples=true", content_type="application/json"
-    )
+    response = client.get("/plates?barcodes=plate_123,456&include_samples=true", content_type="application/json")
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == {


### PR DESCRIPTION
Changes proposed in this pull request:

* update GET /plates endpoint to list barcode params as `barcodes=a,b,c`, not `barcodes[b]=a&barcodes[]=b`

Coupled with https://github.com/sanger/lighthouse-ui/pull/80