### PR TITLE
Update GitHub workflows to match new version numbering

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -37,11 +37,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: nelonoel/branch-name@v1.0.1
+
       - name: Build and tag the image for testing and release
         run: >-
           docker build .
           --file Dockerfile
-          --tag docker.pkg.github.com/${IMAGE_NAME}:${GITHUB_REF##*/}
+          --tag docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
 
       - name: Create SQL Server testing database
         run: >-
@@ -49,7 +51,7 @@ jobs:
           --network host
           --env EVE_SETTINGS=test.py
           --entrypoint ''
-          docker.pkg.github.com/${IMAGE_NAME}:${GITHUB_REF##*/}
+          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
           python setup_sqlserver_test_db.py
 
       - name: Setup the test MLWH and Events databases
@@ -58,7 +60,7 @@ jobs:
           --network host
           --env EVE_SETTINGS=test.py
           --entrypoint ''
-          docker.pkg.github.com/${IMAGE_NAME}:${GITHUB_REF##*/}
+          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
           python setup_test_db.py
 
       - name: Run tests against the image
@@ -67,21 +69,20 @@ jobs:
           --network host
           --env EVE_SETTINGS=test.py
           --entrypoint ''
-          docker.pkg.github.com/${IMAGE_NAME}:${GITHUB_REF##*/}
+          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
           python -m pytest --no-cov -vx
 
       - name: Set release tag
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        run: echo "RELEASE_VERSION=$([ ${GITHUB_REF##*/} = "develop" ] && printf '%s\n' $(cat .release-version)-develop || printf '%s\n' $(cat .release-version))" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=$(printf -- '%s%s\n' $(cat .release-version) $([ ${BRANCH_NAME} = "develop" ] && printf -- '-%s-develop' ${GITHUB_RUN_ID} || echo ""))" >> $GITHUB_ENV
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1.8.8
         with:
           name: ${{ env.RELEASE_VERSION }}
-          tag_name: v${{ env.RELEASE_VERSION }}
+          tag: v${{ env.RELEASE_VERSION }}
           prerelease: ${{ !(github.ref == 'refs/heads/master') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.sha }}
 
       - name: Login to registry
         run: >-
@@ -93,7 +94,7 @@ jobs:
       - name: Tag image with release version
         run: >-
           docker tag
-          docker.pkg.github.com/${IMAGE_NAME}:${GITHUB_REF##*/}
+          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
           docker.pkg.github.com/${IMAGE_NAME}:${{ env.RELEASE_VERSION }}
 
       - name: Push release tag image to registry

--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - master
-      - develop
 
 jobs:
   check:
@@ -13,27 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set excluded release types
-        run: >-
-          if [ "${{ github.base_ref }}" = "master" ]; then
-            echo "exclude_types=draft|prerelease" >> $GITHUB_ENV
-          elif [ "${{ github.base_ref }}" = "develop" ]; then
-            echo "exclude_types=draft" >> $GITHUB_ENV
-          else
-            exit 1;
-          fi
-
       - name: Get the latest release
         id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: pozetroninc/github-action-get-latest-release@v0.5.0
         with:
-          myToken: ${{ github.token }}
-          exclude_types: ${{ env.exclude_types }}
-          view_top: 1
+          owner: Sanger
+          repo: Lighthouse
+          excludes: prerelease, draft
 
       - name: Compare releases
         run: >-
-          if [ "${{ steps.last_release.outputs.tag_name }}" = "$(printf 'v%s-develop\n' $(cat .release-version))" ] ||
-          [ "${{ steps.last_release.outputs.tag_name }}" = "$(printf 'v%s\n' $(cat .release-version))" ]; then
+          if [ "${{ steps.last_release.outputs.release }}" = "$(printf 'v%s\n' $(cat .release-version))" ]; then
             exit 1;
           fi


### PR DESCRIPTION
This avoids having to update the release version at every develop pull request but still enforces that the version change in master.

Part of https://github.com/sanger/deployment/issues/71
