### PR TITLE
Pipenv fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv pipenv==2021.5.29
+          pip install pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv pipenv==2021.5.29
+          pip install pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv pipenv==2021.5.29
+          pip install pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -117,7 +117,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv pipenv==2021.5.29
+          pip install pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv
+          pip install pipenv pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv
+          pip install pipenv pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv
+          pip install pipenv pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system
@@ -117,7 +117,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pipenv
         run: |
-          pip install pipenv
+          pip install pipenv pipenv==2021.5.29
       - name: Install dependencies
         run: |
           pipenv sync --dev --system

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 
 # Install the package manager - pipenv
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir pipenv pipenv==2021.5.29
+    pip install --no-cache-dir pipenv==2021.5.29
 
 # Change the working directory for all proceeding operations
 #   https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 
 # Install the package manager - pipenv
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir pipenv
+    pip install --no-cache-dir pipenv pipenv==2021.5.29
 
 # Change the working directory for all proceeding operations
 #   https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#workdir


### PR DESCRIPTION
pipenv 2021.11.5 has some issues, so pin the version for now
- building the lighthouse docker image was failing with FileNotFoundError: [Errno 2] No such file or directory: '/root/.local/share/virtualenvs/code-_Py8Si6I/bin/python'
