### PR TITLE
DPL-254-3: Filter samples every time we add COG UK IDs

### DIFF
--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from functools import reduce
 from http import HTTPStatus
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, cast
 from uuid import uuid4
@@ -98,24 +99,25 @@ def centre_prefixes_for_samples(samples: List[Dict[str, str]]) -> List[str]:
 
 
 def add_cog_barcodes_from_different_centres(samples: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    # Divide samples in centres and call add_cog_barcodes for each group
+    classified_samples = classify_samples_by_centre(samples)
+
+    # Accumulate and return only the updated samples from each centre's samples list.
+    return reduce(lambda acc, next: acc + add_cog_barcodes(next), classified_samples.values(), [])
+
+
+def add_cog_barcodes(samples):
     # Filter samples to only those that do not already have a COG barcode
     filtered_samples = [
         sample for sample in samples if FIELD_COG_BARCODE not in sample or len(sample[FIELD_COG_BARCODE]) == 0
     ]
 
-    # Divide samples in centres and call add_cog_barcodes for each group
-    classified_samples = classify_samples_by_centre(filtered_samples)
+    num_samples = len(filtered_samples)
+    if num_samples == 0:
+        return []
 
-    for samples_for_one_centre in classified_samples.values():
-        add_cog_barcodes(samples_for_one_centre)
-
-    return filtered_samples
-
-
-def add_cog_barcodes(samples):
-    centre_name = __confirm_centre(samples)
+    centre_name = __confirm_centre(filtered_samples)
     centre_prefix = get_centre_prefix(centre_name)
-    num_samples = len(samples)
 
     logger.info(f"Getting COG-UK barcodes for {num_samples} samples")
 
@@ -133,7 +135,7 @@ def add_cog_barcodes(samples):
                 success_operation = True
                 retries = 0
                 barcodes = response.json()["barcodes_group"]["barcodes"]
-                for (sample, barcode) in zip(samples, barcodes):
+                for (sample, barcode) in zip(filtered_samples, barcodes):
                     sample[FIELD_COG_BARCODE] = barcode
             else:
                 retries = retries - 1
@@ -147,6 +149,8 @@ def add_cog_barcodes(samples):
 
     if not success_operation and except_obj is not None:
         raise except_obj
+
+    return filtered_samples
 
 
 def get_centre_prefix(centre_name):


### PR DESCRIPTION
Closes #509 

Changes proposed in this pull request:

* Use the same filter system for samples to update with new COG UK IDs every time the methods are called.  Even if we don't use the method for "different centres".
