### PR TITLE
DPL-206: Remove add_to_dart key from Mongo documents

### DIFF
--- a/lighthouse/config/schemas.py
+++ b/lighthouse/config/schemas.py
@@ -1,10 +1,6 @@
 from lighthouse.constants.cherrypick_test_data import CPTD_STATUS_PENDING
 
 CHERRYPICK_TEST_DATA_SCHEMA = {
-    "add_to_dart": {
-        "type": "boolean",
-        "required": True,
-    },
     "barcodes": {
         "type": "list",
         "readonly": True,

--- a/tests/endpoints/cherrypick_test_data/test_eve_domain_config.py
+++ b/tests/endpoints/cherrypick_test_data/test_eve_domain_config.py
@@ -7,68 +7,35 @@ ENDPOINT_PREFIXES = ["", "/v1"]
 
 
 @pytest.mark.parametrize("endpoint_prefix", ENDPOINT_PREFIXES)
-@pytest.mark.parametrize(
-    "add_to_dart, plate_specs, error_fields",
-    [
-        ["not_bool", [[1, 96]], ["add_to_dart"]],
-        [1984, [[1, 96]], ["add_to_dart"]],
-        [True, "not_list", ["plate_specs"]],
-        [False, 1984, ["plate_specs"]],
-        ["not_bool", "not_list", ["add_to_dart", "plate_specs"]],
-    ],
-)
-def test_endpoint_generates_issues_for_wrong_types(client, endpoint_prefix, add_to_dart, plate_specs, error_fields):
+@pytest.mark.parametrize("plate_specs", ["not_list", 1984])
+def test_endpoint_generates_issues_for_wrong_types(client, endpoint_prefix, plate_specs):
     response = client.post(
         f"{endpoint_prefix}/cherrypick-test-data",
-        json={"add_to_dart": add_to_dart, "plate_specs": plate_specs},
+        json={"plate_specs": plate_specs},
         follow_redirects=True,
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    for field in error_fields:
-        assert field in response.json["_issues"]
-        assert re.match("must be of \\w+ type", response.json["_issues"][field])
+    assert "plate_specs" in response.json["_issues"]
+    assert re.match("must be of \\w+ type", response.json["_issues"]["plate_specs"])
 
 
 @pytest.mark.parametrize("endpoint_prefix", ENDPOINT_PREFIXES)
-@pytest.mark.parametrize(
-    "add_to_dart, plate_specs, error_fields",
-    [
-        [None, [[1, 96]], ["add_to_dart"]],
-        [True, None, ["plate_specs"]],
-        [None, None, ["add_to_dart", "plate_specs"]],
-    ],
-)
-def test_endpoint_generates_issues_for_null_values(client, endpoint_prefix, add_to_dart, plate_specs, error_fields):
+def test_endpoint_generates_issues_for_null_values(client, endpoint_prefix):
     response = client.post(
         f"{endpoint_prefix}/cherrypick-test-data",
-        json={"add_to_dart": add_to_dart, "plate_specs": plate_specs},
+        json={"plate_specs": None},
         follow_redirects=True,
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    for field in error_fields:
-        assert field in response.json["_issues"]
-        assert re.match("null value not allowed", response.json["_issues"][field])
+    assert "plate_specs" in response.json["_issues"]
+    assert re.match("null value not allowed", response.json["_issues"]["plate_specs"])
 
 
 @pytest.mark.parametrize("endpoint_prefix", ENDPOINT_PREFIXES)
-@pytest.mark.parametrize(
-    "include_add_to_dart, include_plate_specs, error_fields",
-    [
-        [False, True, ["add_to_dart"]],
-        [True, False, ["plate_specs"]],
-        [False, False, ["add_to_dart", "plate_specs"]],
-    ],
-)
-def test_endpoint_generates_issues_for_missing_values(
-    client, endpoint_prefix, include_add_to_dart, include_plate_specs, error_fields
-):
+def test_endpoint_generates_issues_for_missing_values(client, endpoint_prefix):
     json_obj: dict = {}
-    if include_add_to_dart:
-        json_obj["add_to_dart"] = True
-    if include_plate_specs:
-        json_obj["plate_specs"] = [[1, 96]]
 
     response = client.post(
         f"{endpoint_prefix}/cherrypick-test-data",
@@ -77,16 +44,15 @@ def test_endpoint_generates_issues_for_missing_values(
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    for field in error_fields:
-        assert field in response.json["_issues"]
-        assert response.json["_issues"][field] == "required field"
+    assert "plate_specs" in response.json["_issues"]
+    assert response.json["_issues"]["plate_specs"] == "required field"
 
 
 @pytest.mark.parametrize("endpoint_prefix", ENDPOINT_PREFIXES)
 def test_endpoint_generates_issues_for_extra_values(client, endpoint_prefix):
     response = client.post(
         f"{endpoint_prefix}/cherrypick-test-data",
-        json={"add_to_dart": True, "plate_specs": [[1, 96]], "extra_value": "extra"},
+        json={"plate_specs": [[1, 96]], "extra_value": "extra"},
         follow_redirects=True,
     )
 
@@ -99,7 +65,7 @@ def test_endpoint_generates_issues_for_extra_values(client, endpoint_prefix):
 def test_endpoint_generates_issues_for_bulk_insert(client, endpoint_prefix):
     response = client.post(
         f"{endpoint_prefix}/cherrypick-test-data",
-        json=[{"add_to_dart": True, "plate_specs": [[1, 96]]}, {"add_to_dart": False, "plate_specs": [[1, 96]]}],
+        json=[{"plate_specs": [[1, 96]]}, {"plate_specs": [[1, 96]]}],
         follow_redirects=True,
     )
 

--- a/tests/endpoints/cherrypick_test_data/test_valid_input.py
+++ b/tests/endpoints/cherrypick_test_data/test_valid_input.py
@@ -15,17 +15,17 @@ CRAWLER_URL = f"{CRAWLER_BASE_URL}/v1/cherrypick-test-data"
 ENDPOINT_PATH = "/cherrypick-test-data"
 
 
-def valid_json_object(add_to_dart: bool = True, plate_specs: List[List[int]] = None) -> dict:
+def valid_json_object(plate_specs: List[List[int]] = None) -> dict:
     if plate_specs is None:
         plate_specs = [[1, 96]]
 
-    return {"add_to_dart": add_to_dart, "plate_specs": plate_specs}
+    return {"plate_specs": plate_specs}
 
 
-@pytest.mark.parametrize("add_to_dart, plate_specs", [[True, [[1, 0], [2, 96]]], [False, [[100, 48], [100, 96]]]])
-def test_create_run_successful(client, add_to_dart, plate_specs):
+@pytest.mark.parametrize("plate_specs", [[[1, 0], [2, 96]], [[100, 48], [100, 96]]])
+def test_create_run_successful(client, plate_specs):
     with patch("requests.post"):
-        post_response = client.post(ENDPOINT_PATH, json=valid_json_object(add_to_dart, plate_specs))
+        post_response = client.post(ENDPOINT_PATH, json=valid_json_object(plate_specs))
 
     assert post_response.status_code == HTTPStatus.CREATED
 
@@ -34,7 +34,6 @@ def test_create_run_successful(client, add_to_dart, plate_specs):
 
     assert get_response.status_code == HTTPStatus.OK
     assert get_response.json["status"] == CPTD_STATUS_PENDING
-    assert get_response.json["add_to_dart"] == add_to_dart
     assert get_response.json["plate_specs"] == plate_specs
 
 

--- a/tests/validators/test_cherrypick_test_data_validators.py
+++ b/tests/validators/test_cherrypick_test_data_validators.py
@@ -2,10 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from lighthouse.constants.error_messages import (
-    ERROR_PLATE_SPECS_EMPTY_LIST,
-    ERROR_PLATE_SPECS_INVALID_FORMAT,
-)
+from lighthouse.constants.error_messages import ERROR_PLATE_SPECS_EMPTY_LIST, ERROR_PLATE_SPECS_INVALID_FORMAT
 
 
 @pytest.mark.parametrize(
@@ -25,7 +22,7 @@ from lighthouse.constants.error_messages import (
 def test_plate_specs_validator_generates_correct_errors(client, plate_specs, error_message):
     response = client.post(
         "/cherrypick-test-data",
-        json={"add_to_dart": True, "plate_specs": plate_specs},
+        json={"plate_specs": plate_specs},
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Closes #480 

Changes proposed in this pull request:

* Remove add_to_dart key in Lighthouse API
