### PR TITLE
DPL-631: Fix must sequence as fit to pick

### DIFF
--- a/lighthouse/constants/aggregation_stages.py
+++ b/lighthouse/constants/aggregation_stages.py
@@ -74,38 +74,34 @@ STAGES_FIT_TO_PICK_SAMPLES: Final[List[Dict[str, Any]]] = [
         "$match": {
             "$or": [
                 {FIELD_FILTERED_POSITIVE: True},
-                {
-                    FIELD_PROCESSED: True,
-                    FIELD_MUST_SEQUENCE: True,
-                },
+                {FIELD_MUST_SEQUENCE: True},
+            ],
+        }
+    },
+    # add facets to make extracting counts efficient
+    {
+        "$facet": {
+            FACET_FIT_TO_PICK_SAMPLES: [
+                {"$match": {}},
+            ],
+            FACET_COUNT_FIT_TO_PICK_SAMPLES: [
+                {"$count": "count"},
+            ],
+            FACET_COUNT_FILTERED_POSITIVE: [
+                {"$match": {FIELD_FILTERED_POSITIVE: True}},
+                {"$count": "count"},
+            ],
+            FACET_COUNT_MUST_SEQUENCE: [
+                {"$match": {FIELD_MUST_SEQUENCE: True}},
+                {"$count": "count"},
+            ],
+            FACET_COUNT_PREFERENTIALLY_SEQUENCE: [
+                {"$match": {FIELD_PREFERENTIALLY_SEQUENCE: True}},
+                {"$count": "count"},
             ],
         }
     },
 ]
-
-# add facets to make extracting counts efficient
-FACETS_FIT_TO_PICK = {
-    "$facet": {
-        FACET_FIT_TO_PICK_SAMPLES: [
-            {"$match": {}},
-        ],
-        FACET_COUNT_FIT_TO_PICK_SAMPLES: [
-            {"$count": "count"},
-        ],
-        FACET_COUNT_FILTERED_POSITIVE: [
-            {"$match": {FIELD_FILTERED_POSITIVE: True}},
-            {"$count": "count"},
-        ],
-        FACET_COUNT_MUST_SEQUENCE: [
-            {"$match": {FIELD_MUST_SEQUENCE: True}},
-            {"$count": "count"},
-        ],
-        FACET_COUNT_PREFERENTIALLY_SEQUENCE: [
-            {"$match": {FIELD_PREFERENTIALLY_SEQUENCE: True}},
-            {"$count": "count"},
-        ],
-    }
-}
 
 FACETS_REPORT = {
     "$facet": {

--- a/lighthouse/helpers/general.py
+++ b/lighthouse/helpers/general.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from eve import Eve
 from flask import current_app as app
 
-from lighthouse.constants.aggregation_stages import FACETS_FIT_TO_PICK, STAGES_FIT_TO_PICK_SAMPLES
+from lighthouse.constants.aggregation_stages import STAGES_FIT_TO_PICK_SAMPLES
 from lighthouse.constants.fields import FIELD_PLATE_BARCODE
 from lighthouse.constants.general import (
     FACET_COUNT_FILTERED_POSITIVE,
@@ -28,9 +28,8 @@ def get_fit_to_pick_samples_and_counts(
     # We are only interested in the samples for a particular plate
     pipeline: List[Dict[str, Any]] = [{"$match": {FIELD_PLATE_BARCODE: plate_barcode}}]
 
-    #  Prepare the stages we need
+    # Extend with the stages we need
     pipeline.extend(STAGES_FIT_TO_PICK_SAMPLES)
-    pipeline.append(FACETS_FIT_TO_PICK)
 
     pretty(logger, pipeline)
 

--- a/tests/fixtures/data/plates_lookup.py
+++ b/tests/fixtures/data/plates_lookup.py
@@ -2,9 +2,9 @@ PLATES_LOOKUP_WITHOUT_SAMPLES = {
     "plate_123": {
         "plate_barcode": "plate_123",
         "has_plate_map": True,
-        "count_fit_to_pick_samples": 4,
+        "count_fit_to_pick_samples": 5,
         "count_filtered_positive": 3,
-        "count_must_sequence": 1,
+        "count_must_sequence": 2,
         "count_preferentially_sequence": 1,
     }
 }
@@ -13,9 +13,9 @@ PLATES_LOOKUP_WITH_SAMPLES = {
     "plate_123": {
         "plate_barcode": "plate_123",
         "has_plate_map": True,
-        "count_fit_to_pick_samples": 4,
+        "count_fit_to_pick_samples": 5,
         "count_filtered_positive": 3,
-        "count_must_sequence": 1,
+        "count_must_sequence": 2,
         "count_preferentially_sequence": 1,
         "pickable_samples": [
             {
@@ -45,6 +45,13 @@ PLATES_LOOKUP_WITH_SAMPLES = {
                 "sample_id": "2a53e7b6-7ce8-4ebc-95c3-02dd64942532",
                 "source_coordinate_padded": "E01",
                 "source_coordinate_unpadded": "E1",
+            },
+            {
+                "lab_id": "lab_1",
+                "rna_id": "rna_pl",
+                "sample_id": "69855245-a66b-4172-ab46-a1d344b5ca8b",
+                "source_coordinate_padded": "F01",
+                "source_coordinate_unpadded": "F1",
             },
         ],
     }

--- a/tests/fixtures/data/samples.py
+++ b/tests/fixtures/data/samples.py
@@ -8,6 +8,7 @@ from lighthouse.constants.fields import (
     FIELD_LAB_ID,
     FIELD_LH_SAMPLE_UUID,
     FIELD_LH_SOURCE_PLATE_UUID,
+    FIELD_MUST_SEQUENCE,
     FIELD_PLATE_BARCODE,
     FIELD_RESULT,
     FIELD_RNA_ID,
@@ -184,6 +185,22 @@ SAMPLES = [
         FIELD_DATE_TESTED: DATE_TESTED_NOW,
         FIELD_FILTERED_POSITIVE: True,
         FIELD_LAB_ID: "lab_4",
+    },
+    {
+        # a Negative result
+        # should be picked because marked as must_sequence = True
+        FIELD_COORDINATE: "F01",
+        FIELD_SOURCE: "centre_1",
+        FIELD_RESULT: "Negative",
+        FIELD_PLATE_BARCODE: "plate_123",
+        FIELD_ROOT_SAMPLE_ID: "sample_842",
+        FIELD_RNA_ID: "rna_pl",
+        FIELD_COG_BARCODE: "jih",
+        FIELD_LH_SAMPLE_UUID: "69855245-a66b-4172-ab46-a1d344b5ca8b",
+        FIELD_DATE_TESTED: DATE_TESTED_NOW,
+        FIELD_FILTERED_POSITIVE: False,
+        FIELD_MUST_SEQUENCE: True,
+        FIELD_LAB_ID: "lab_1",
     },
 ]
 

--- a/tests/helpers/test_general_helpers.py
+++ b/tests/helpers/test_general_helpers.py
@@ -11,9 +11,9 @@ def test_get_fit_to_pick_samples_count_valid_barcode(app, samples, priority_samp
             count_filtered_positive,
         ) = get_fit_to_pick_samples_and_counts("plate_123")
         if fit_to_pick_samples:
-            assert len(fit_to_pick_samples) == 4
-            assert count_fit_to_pick_samples == 4
-            assert count_must_sequence == 1
+            assert len(fit_to_pick_samples) == 5
+            assert count_fit_to_pick_samples == 5
+            assert count_must_sequence == 2
             # one not two as only one preferentially_sequence sample is also a filtered positive and should be picked
             assert count_preferentially_sequence == 1
             assert count_filtered_positive == 3

--- a/tests/helpers/test_plates_helpers.py
+++ b/tests/helpers/test_plates_helpers.py
@@ -98,7 +98,7 @@ def any_failure_type(app):
 def test_classify_samples_by_centre(app, samples, mocked_responses):
     samples, _ = samples
     assert list(classify_samples_by_centre(samples).keys()) == ["centre_1", "centre_2"]
-    assert len(classify_samples_by_centre(samples)["centre_1"]) == 10
+    assert len(classify_samples_by_centre(samples)["centre_1"]) == 11
     assert len(classify_samples_by_centre(samples)["centre_2"]) == 1
 
 
@@ -440,6 +440,7 @@ def test_check_matching_sample_numbers_returns_true_match(samples):
         DartRow.with_id_fields("DN1111", "A09", "DN2222", "C04", None, "sample_1", "plate1:A02", "ABC"),
         DartRow.with_id_fields("DN1111", "A10", "DN2222", "C04", None, "sample_1", "plate1:A02", "ABC"),
         DartRow.with_id_fields("DN1111", "A11", "DN2222", "C04", None, "sample_1", "plate1:A02", "ABC"),
+        DartRow.with_id_fields("DN1111", "A12", "DN2222", "C04", None, "sample_1", "plate1:A02", "ABC"),
         DartRow.with_id_fields("DN3333", "A04", "DN2222", "C01", "positive", None, None, None),
         DartRow.with_id_fields("DN3333", "A04", "DN2222", "C01", "negative", None, None, None),
     ]

--- a/tests/routes/v1/test_plates.py
+++ b/tests/routes/v1/test_plates.py
@@ -28,7 +28,7 @@ def test_post_plates_endpoint_successful_all_cog_barcodes_already_in_samples(
     response = client.post(endpoint, json=body)
     assert response.status_code == HTTPStatus.CREATED
     assert response.json == {
-        "data": {"plate_barcode": "plate_123", "centre": "centre_1", "count_fit_to_pick_samples": 4}
+        "data": {"plate_barcode": "plate_123", "centre": "centre_1", "count_fit_to_pick_samples": 5}
     }
 
 


### PR DESCRIPTION
Closes #700 

Changes proposed in this pull request:

* Update the Mongo query so that must sequence == True makes a sample fit to pick even if there is no field named "processed".
* Update unit tests to catch this in case of a regression.
