### PR TITLE
DPL-782 fix existing plate response

### DIFF
--- a/lighthouse/helpers/plates.py
+++ b/lighthouse/helpers/plates.py
@@ -247,19 +247,6 @@ def request_with_retries(request_func: Callable, response_func: Callable[[Any], 
     raise requests.ConnectionError("Unable to access Sequencescape.")
 
 
-def plate_exists_in_ss_with_uuid(uuid: str) -> bool:
-    ss_url = f"{app.config['SS_URL']}/api/v2/plates"
-    params = {"filter[uuid]": uuid}
-    headers = _ss_headers()
-
-    LOGGER.debug(f"Searching Sequencescape for plate with UUID: '{uuid}'.")
-
-    return request_with_retries(
-        request_func=lambda: requests.get(ss_url, params=params, headers=headers),
-        response_func=lambda response: len(response.json()["data"]) > 0,
-    )
-
-
 def filter_for_new_samples(samples: List[Dict[str, str]]) -> List[Dict[str, str]]:
     def is_sample_new(sample: Dict[str, str]) -> bool:
         sample_uuid = sample[FIELD_LH_SAMPLE_UUID]

--- a/lighthouse/routes/common/plates.py
+++ b/lighthouse/routes/common/plates.py
@@ -29,7 +29,7 @@ from lighthouse.helpers.plates import (
     filter_for_new_samples,
     format_plate,
     get_from_ss_plates_samples_info,
-    plate_exists_in_ss_with_uuid,
+    plate_exists_in_ss_with_barcode,
     send_to_ss_heron_plates,
 )
 from lighthouse.helpers.responses import bad_request, internal_server_error, ok
@@ -157,7 +157,7 @@ def _create_plate_from_barcode(barcode: str, plate_config: dict) -> FlaskRespons
     if plate_uuid is None:
         return bad_request(f"No plate exists for barcode: {barcode}")
 
-    if plate_exists_in_ss_with_uuid(plate_uuid):
+    if plate_exists_in_ss_with_barcode(barcode):
         return bad_request(f"The barcode '{barcode}' is already in use.")
 
     samples = get_all_samples_for_source_plate(plate_uuid)


### PR DESCRIPTION
Closes #779 

Changes proposed in this pull request:

* Switch to checking existence of plates using barcode rather than UUID.

As it turns out, the UUID in Sequencescape for plates that have been created via the API do not match those in MongoDB.  I hadn't realised this in the previous work and the test data I used obscured this fact.