### PR TITLE
Update-flake8-bugbear

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1228,11 +1228,11 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
-                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+                "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
+                "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.1.0"
+            "version": "==23.2.0"
         },
         "black": {
             "hashes": [
@@ -1456,11 +1456,12 @@
         },
         "flake8-bugbear": {
             "hashes": [
-                "sha256:0ebdc7d8ec1ca8bd49347694562381f099f4de2f8ec6bda7a7dca65555d9e0d4",
-                "sha256:d99d005114020fbef47ed5e4aebafd22f167f9a0fbd0d8bf3c9e90612cb25c34"
+                "sha256:663ef5de80cd32aacd39d362212983bc4636435a6f83700b4ed35acbd0b7d1b8",
+                "sha256:f9cb5f2a9e792dd80ff68e89a14c12eed8620af8b41a49d823b7a33064ac9658"
             ],
             "index": "pypi",
-            "version": "==23.7.10"
+            "markers": "python_full_version >= '3.8.1'",
+            "version": "==24.2.6"
         },
         "freezegun": {
             "hashes": [

--- a/tests/classes/event_properties/test_event_property_definitions.py
+++ b/tests/classes/event_properties/test_event_property_definitions.py
@@ -373,6 +373,7 @@ def test_source_plate_uuid_value(app, source_plates):
             SourcePlateUUID(PlateBarcode({})).value
             SourcePlateUUID(PlateBarcode({"test": "another test"})).value
 
+        SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"})).value
         with raises(Exception):
             SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"})).value
 
@@ -395,6 +396,7 @@ def test_source_plate_uuid_errors(app, source_plates):
 
         # After retrieval error
         source_plate_property = SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"}))
+        source_plate_property.value
         with raises(Exception):
             source_plate_property.value
 

--- a/tests/classes/event_properties/test_event_property_definitions.py
+++ b/tests/classes/event_properties/test_event_property_definitions.py
@@ -395,8 +395,7 @@ def test_source_plate_uuid_errors(app, source_plates):
 
         # After retrieval error
         source_plate_property = SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"}))
-        source_plate_property.value
-        with raises(Exception):
+        with raises(Exception, match="Source plate with barcode '1234' not found"):
             source_plate_property.value
 
         assert len(source_plate_property.errors) > 0

--- a/tests/classes/event_properties/test_event_property_definitions.py
+++ b/tests/classes/event_properties/test_event_property_definitions.py
@@ -373,8 +373,7 @@ def test_source_plate_uuid_value(app, source_plates):
             SourcePlateUUID(PlateBarcode({})).value
             SourcePlateUUID(PlateBarcode({"test": "another test"})).value
 
-        SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"})).value
-        with raises(Exception):
+        with raises(Exception, match="Source plate with barcode '1234' not found"):
             SourcePlateUUID(PlateBarcode({FIELD_EVENT_BARCODE: "1234"})).value
 
         uuid = source_plates[0][FIELD_LH_SOURCE_PLATE_UUID]

--- a/tests/helpers/test_dart.py
+++ b/tests/helpers/test_dart.py
@@ -23,8 +23,6 @@ def test_find_dart_source_samples_rows_not_found_barcode(app, dart_samples):
 
 def test_exceptions_are_propagated_up(app, dart_samples):
     with app.app_context():
-        with patch("lighthouse.helpers.dart.create_dart_connection", side_effect=Exception()):
-            found = find_dart_source_samples_rows("unknown") # XXX: Raise exception here
-            with raises(Exception):
-                found = find_dart_source_samples_rows("unknown")
-                assert found is None
+        with patch("lighthouse.helpers.dart.create_dart_connection", side_effect=Exception("test exception")):
+            with raises(Exception, match="test exception"):
+                find_dart_source_samples_rows("unknown")

--- a/tests/helpers/test_dart.py
+++ b/tests/helpers/test_dart.py
@@ -24,6 +24,7 @@ def test_find_dart_source_samples_rows_not_found_barcode(app, dart_samples):
 def test_exceptions_are_propagated_up(app, dart_samples):
     with app.app_context():
         with patch("lighthouse.db.dart.create_dart_connection", side_effect=Exception()):
+            found = find_dart_source_samples_rows("unknown")
             with raises(Exception):
                 found = find_dart_source_samples_rows("unknown")
                 assert found is None

--- a/tests/helpers/test_dart.py
+++ b/tests/helpers/test_dart.py
@@ -23,8 +23,8 @@ def test_find_dart_source_samples_rows_not_found_barcode(app, dart_samples):
 
 def test_exceptions_are_propagated_up(app, dart_samples):
     with app.app_context():
-        with patch("lighthouse.db.dart.create_dart_connection", side_effect=Exception()):
-            found = find_dart_source_samples_rows("unknown")
+        with patch("lighthouse.helpers.dart.create_dart_connection", side_effect=Exception()):
+            found = find_dart_source_samples_rows("unknown") # XXX: Raise exception here
             with raises(Exception):
                 found = find_dart_source_samples_rows("unknown")
                 assert found is None


### PR DESCRIPTION
Created for inspecting the dependabot PR https://github.com/sanger/lighthouse/pull/881

Bumps [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) from 23.7.10 to 24.2.6.
- [Release notes](https://github.com/PyCQA/flake8-bugbear/releases)
- [Commits](https://github.com/PyCQA/flake8-bugbear/compare/23.7.10...24.2.6)

---
updated-dependencies:
- dependency-name: flake8-bugbear dependency-type: direct:development update-type: version-update:semver-major ...

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
